### PR TITLE
pathlib migration: migrate `Library.directory` to `pathlib.Path`

### DIFF
--- a/beets/context.py
+++ b/beets/context.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import os
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from beets.util import PathLike
 
 # Holds the music dir context
 _music_dir_var: ContextVar[bytes] = ContextVar("music_dir", default=b"")
@@ -16,15 +19,15 @@ def get_music_dir() -> bytes:
     return _music_dir_var.get()
 
 
-def set_music_dir(value: bytes) -> None:
+def set_music_dir(value: PathLike) -> None:
     """Set the current music directory context."""
-    _music_dir_var.set(value)
+    _music_dir_var.set(os.fsencode(value))
 
 
 @contextmanager
-def music_dir(value: bytes) -> Iterator[None]:
+def music_dir(value: PathLike) -> Iterator[None]:
     """Temporarily bind the active music directory for query parsing."""
-    token = _music_dir_var.set(value)
+    token = _music_dir_var.set(os.fsencode(value))
     try:
         yield
     finally:

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -837,7 +837,7 @@ class ImportTask(BaseImportTask):
 
     # Utilities.
 
-    def prune(self, filename: util.PathBytes) -> None:
+    def prune(self, filename: util.PathLike) -> None:
         """Prune any empty directories above the given file. If this
         task has no `toppath` or the file path provided is not within
         the `toppath`, then this function has no effect. Similarly, if

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -387,11 +387,9 @@ class ImportTask(BaseImportTask):
         log.debug("removing {} old duplicate albums", len(duplicate_albums))
 
         for album in duplicate_albums:
-            artpath = album.artpath
-
             for item in album.items():
                 item.remove(with_album=False)
-                if lib.directory in util.ancestry(item.path):
+                if lib.is_in_directory(item):
                     log.debug("deleting duplicate {.filepath}", item)
                     util.remove(item.path)
                     util.prune_dirs(
@@ -402,7 +400,7 @@ class ImportTask(BaseImportTask):
 
             album.remove(with_items=False)
 
-            if artpath and lib.directory in util.ancestry(artpath):
+            if (artpath := album.art_filepath) and lib.contains_path(artpath):
                 log.debug("deleting duplicate album art {}", artpath)
                 util.remove(artpath)
                 util.prune_dirs(
@@ -425,7 +423,7 @@ class ImportTask(BaseImportTask):
         log.debug("upgrade: removing {} superseded item(s)", len(superseded))
         for item in superseded:
             item.remove(with_album=False)
-            if lib.directory in util.ancestry(item.path):
+            if lib.is_in_directory(item):
                 log.debug("deleting superseded {.filepath}", item)
                 util.remove(item.path)
                 util.prune_dirs(
@@ -442,9 +440,10 @@ class ImportTask(BaseImportTask):
 
             surviving = list(old_album.items())
             if not surviving:
-                artpath = old_album.artpath
                 old_album.remove(with_items=False)
-                if artpath and lib.directory in util.ancestry(artpath):
+                if (artpath := old_album.art_filepath) and lib.contains_path(
+                    artpath
+                ):
                     log.debug("deleting duplicate album art {}", artpath)
                     util.remove(artpath)
                     util.prune_dirs(
@@ -664,7 +663,7 @@ class ImportTask(BaseImportTask):
                 if (
                     operation != util.MoveOperation.MOVE
                     and self.replaced_items[item]
-                    and session.lib.directory in util.ancestry(old_path)
+                    and session.lib.contains_path(item.filepath)
                 ):
                     item.move()
                     # We moved the item, so remove the
@@ -927,7 +926,7 @@ class SingletonImportTask(ImportTask):
         log.debug("removing {} old duplicated items", len(duplicate_items))
         for item in duplicate_items:
             item.remove()
-            if lib.directory in util.ancestry(item.path):
+            if lib.is_in_directory(item):
                 log.debug("deleting duplicate {.filepath}", item)
                 util.remove(item.path)
                 util.prune_dirs(
@@ -947,7 +946,7 @@ class SingletonImportTask(ImportTask):
         log.debug("upgrade: removing {} superseded item(s)", len(superseded))
         for item in superseded:
             item.remove()
-            if lib.directory in util.ancestry(item.path):
+            if lib.is_in_directory(item):
                 log.debug("deleting superseded {.filepath}", item)
                 util.remove(item.path)
                 util.prune_dirs(

--- a/beets/library/exceptions.py
+++ b/beets/library/exceptions.py
@@ -8,7 +8,7 @@ class FileOperationError(Exception):
     error, and an unhandled Mutagen exception.
     """
 
-    def __init__(self, path: bytes, reason: Exception) -> None:
+    def __init__(self, path: util.PathLike, reason: Exception) -> None:
         """Create an exception describing an operation on the file at
         `path` with the underlying (chained) exception `reason`.
         """

--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -77,7 +77,7 @@ class Library(dbcore.Database):
         directory: str | None = None,
         set_music_dir: bool = True,
     ) -> None:
-        self.directory = normpath(directory or platformdirs.user_music_path())
+        self.directory = normpath(directory or platformdirs.user_music_dir())
         if set_music_dir:
             context.set_music_dir(self.directory)
 

--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -52,6 +52,7 @@ class Library(dbcore.Database):
     # Used for template substitution performance.
     _memotable: dict[tuple[str | None, str | None, str | None, int | None], str]
     replacements: Replacements
+    directory: Path
 
     @cached_property
     def path_formats(self) -> list[PathFormat]:
@@ -74,10 +75,10 @@ class Library(dbcore.Database):
     def __init__(
         self,
         path: PathLike = Path("library.blb"),
-        directory: str | None = None,
+        directory: Path | None = None,
         set_music_dir: bool = True,
     ) -> None:
-        self.directory = normpath(directory or platformdirs.user_music_dir())
+        self.directory = normpath(directory or platformdirs.user_music_path())
         if set_music_dir:
             context.set_music_dir(self.directory)
 
@@ -91,6 +92,14 @@ class Library(dbcore.Database):
         """Temporarily bind this library's directory to path conversion."""
         with context.music_dir(self.directory):
             yield self
+
+    def contains_path(self, path: Path) -> bool:
+        """Return whether the given path is in the library's directory."""
+        return path.is_relative_to(self.directory)
+
+    def is_in_directory(self, model: LibModel) -> bool:
+        """Return whether the model is in the library's directory."""
+        return self.contains_path(model.filepath)
 
     # Adding objects to the database.
 

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -482,7 +482,7 @@ class Album(LibModel):
         the album is not stored automatically, and it will have to be manually
         stored after invoking this method.
         """
-        basedir = basedir or self.db.directory
+        basedir = basedir or os.fsencode(self.db.directory)
 
         # Ensure new metadata is available to items for destination
         # computation.
@@ -1026,7 +1026,7 @@ class Item(LibModel):
             self.try_write()
         if move:
             # Check whether this file is inside the library directory.
-            if self._db and self._db.directory in util.ancestry(self.path):
+            if self._db and self.db.is_in_directory(self):
                 log.debug("moving {.filepath} to synchronize path", self)
                 self.move(with_album=with_album)
         self.store()
@@ -1235,7 +1235,7 @@ class Item(LibModel):
         is true, returns just the fragment of the path underneath the library
         base directory.
         """
-        basedir = basedir or self.db.directory
+        basedir = basedir or os.fsencode(self.db.directory)
         path_formats = path_formats or self.db.path_formats
 
         for query_str, path_format in path_formats:

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -914,7 +914,7 @@ class Item(LibModel):
         if read_path is None:
             read_path = self.path
         else:
-            read_path = normpath(read_path)
+            read_path = os.fsencode(normpath(read_path))
         try:
             mediafile = MediaFile(syspath(read_path))
         except UnreadableFileError as exc:

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -861,10 +861,8 @@ def apply_item_changes(
     if pretend:
         return
 
-    from beets import util
-
     # Move the item if it's in the library.
-    if move and lib.directory in util.ancestry(item.path):
+    if move and lib.is_in_directory(item):
         item.move(with_album=False)
 
     if write:

--- a/beets/test/_common.py
+++ b/beets/test/_common.py
@@ -14,7 +14,6 @@ import beets.library
 # Make sure the development versions of the plugins are used
 from beets import importer, logging
 from beets.ui import commands
-from beets.util import syspath
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -148,13 +147,6 @@ class DummyIO:
         """
         # Using capteesys allows you to see output in the console if the test fails
         return self._capteesys.readouterr().out
-
-
-# Utility.
-
-
-def touch(path: bytes) -> None:
-    open(syspath(path), "a").close()
 
 
 # Platform mocking.

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -260,7 +260,7 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
             if self.db_on_disk
             else Path(":memory:")
         )
-        self.lib = Library(dbpath, str(self.lib_path))
+        self.lib = Library(dbpath, self.lib_path)
 
     def teardown_beets(self) -> None:
         self.env_patcher.stop()

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -854,18 +854,13 @@ def _open_library(config: confuse.LazyConfig) -> library.Library:
     dbpath = config["library"].as_path()
     _ensure_db_directory_exists(dbpath)
     try:
-        lib = library.Library(dbpath, config["directory"].as_filename())
+        lib = library.Library(dbpath, config["directory"].as_path())
         lib.get_item(0)  # Test database connection.
     except (sqlite3.OperationalError, sqlite3.DatabaseError) as db_error:
         log.debug("{}", traceback.format_exc())
-        raise UserError(
-            f"database file {util.displayable_path(dbpath)} cannot not be"
-            f" opened: {db_error}"
-        )
+        raise UserError(f"database file {dbpath} cannot be opened: {db_error}")
     log.debug(
-        "library database: {}\nlibrary directory: {}",
-        util.displayable_path(lib.path),
-        util.displayable_path(lib.directory),
+        "library database: {}\nlibrary directory: {}", lib.path, lib.directory
     )
     return lib
 

--- a/beets/ui/commands/update.py
+++ b/beets/ui/commands/update.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from beets import library, logging, ui
 from beets.exceptions import UserError
-from beets.util import ancestry, syspath
+from beets.util import syspath
 from beets.util.color import colorize
 
 if TYPE_CHECKING:
@@ -119,7 +119,7 @@ def update_items(
             if not pretend:
                 if changed:
                     # Move the item if it's in the library.
-                    if move and lib.directory in ancestry(item.path):
+                    if move and lib.is_in_directory(item):
                         item.move(store=False)
 
                     item.store(fields=item_fields)
@@ -153,7 +153,7 @@ def update_items(
             album.store(fields=album_fields)
 
             # Move album art (and any inconsistent items).
-            if move and lib.directory in ancestry(first_item.path):
+            if move and lib.is_in_directory(first_item):
                 log.debug("moving album {}", album_id)
 
                 # Manually moving and storing the album.
@@ -167,9 +167,9 @@ def update_items(
 
 def update_func(lib: Library, opts: UpdateCLIOpts, args: list[str]) -> None:
     # Verify that the library folder exists to prevent accidental wipes.
-    if not os.path.isdir(syspath(lib.directory)):
+    if not lib.directory.is_dir():
         ui.print_("Library path is unavailable or does not exist.")
-        ui.print_(os.fsdecode(lib.directory))
+        ui.print_(str(lib.directory))
         if not ui.input_yn("Are you sure you want to continue (y/n)?", True):
             return
     if opts.album:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -35,6 +35,7 @@ from typing import (
     NamedTuple,
     TypeVar,
     cast,
+    overload,
 )
 
 from typing_extensions import Self
@@ -173,13 +174,23 @@ class PromptChoice(NamedTuple):
     callback: Callable[[ImportSession, ImportTask], Action | None] | None
 
 
-def normpath(path: PathLike) -> bytes:
+@overload
+def normpath(path: Path) -> Path: ...
+@overload
+def normpath(path: str | bytes) -> bytes: ...
+def normpath(path: PathLike | Path) -> bytes | Path:
     """Provide the canonical form of the path suitable for storing in
     the database.
     """
+    # TODO: use path.expanduser().resolve() once beets.util.pathutils are
+    # migrated to pathlib. Path.resolve() expands Windows paths like
+    # RUNNER~1 -> runneradmin, while os utils do not. We're keeping legacy
+    # logic temporarily for consistency with paths stored in the db.
     str_path = os.fsdecode(path)
     str_path = os.path.normpath(os.path.abspath(os.path.expanduser(str_path)))
-    return bytestring_path(str_path)
+    if isinstance(path, Path):
+        return Path(str_path)
+    return os.fsencode(str_path)
 
 
 def ancestry(path: AnyStr) -> list[AnyStr]:
@@ -316,9 +327,9 @@ def prune_dirs(
     emptiness. If root is not provided, then only path may be removed
     (i.e., no recursive removal).
     """
-    path = normpath(path)
-    root = normpath(root) if root else None
-    ancestors = ancestry(path)
+    path = Path(os.fsdecode(normpath(path)))
+    root = Path(os.fsdecode(normpath(root))) if root else None
+    ancestors = list(reversed(path.parents))
 
     if root is None:
         # Only remove the top directory.
@@ -1168,7 +1179,7 @@ def get_temp_filename(
     prefix: str = "",
     path: PathLike | None = None,
     suffix: str = "",
-) -> bytes:
+) -> Path:
     """Return temporary filename for the given module and prefix.
 
     The filename starts with the given `prefix`.
@@ -1185,7 +1196,7 @@ def get_temp_filename(
         dir=tempdir, prefix=prefix, suffix=suffix
     )
     os.close(descriptor)
-    return bytestring_path(filename)
+    return Path(filename)
 
 
 def unique_list(elements: Iterable[T]) -> list[T]:

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -17,15 +17,11 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import urlencode
 
 from beets import logging, util
-from beets.util import (
-    LazySharedInstance,
-    displayable_path,
-    get_temp_filename,
-    syspath,
-)
+from beets.util import LazySharedInstance, get_temp_filename, syspath
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from pathlib import Path
 
 PROXY_URL = "https://images.weserv.nl/"
 
@@ -81,37 +77,35 @@ class LocalBackend(ABC):
     def resize(
         self,
         maxwidth: int,
-        path_in: bytes,
-        path_out: bytes | None = None,
+        path_in: Path,
+        path_out: Path | None = None,
         quality: int = 0,
         max_filesize: int = 0,
-    ) -> bytes:
+    ) -> Path:
         """Resize an image to the given width and return the output path.
 
         On error, logs a warning and returns `path_in`.
         """
 
     @abstractmethod
-    def get_size(self, path_in: bytes) -> tuple[int, int] | None:
+    def get_size(self, path_in: util.PathLike) -> tuple[int, int] | None:
         """Return the (width, height) of the image or None if unavailable."""
 
     @abstractmethod
-    def deinterlace(
-        self, path_in: bytes, path_out: bytes | None = None
-    ) -> bytes:
+    def deinterlace(self, path_in: Path, path_out: Path | None = None) -> Path:
         """Remove interlacing from an image and return the output path.
 
         On error, logs a warning and returns `path_in`.
         """
 
     @abstractmethod
-    def get_format(self, path_in: bytes) -> str | None:
+    def get_format(self, path_in: util.PathLike) -> str | None:
         """Return the image format (e.g., 'PNG') or None if undetectable."""
 
     @abstractmethod
     def convert_format(
-        self, source: bytes, target: bytes, deinterlaced: bool
-    ) -> bytes:
+        self, source: Path, target: Path, deinterlaced: bool
+    ) -> Path:
         """Convert an image to a new format and return the new file path.
 
         On error, logs a warning and returns `source`.
@@ -123,7 +117,7 @@ class LocalBackend(ABC):
         return False
 
     def compare(
-        self, im1: bytes, im2: bytes, compare_threshold: float
+        self, im1: util.PathLike, im2: util.PathLike, compare_threshold: float
     ) -> bool | None:
         """Compare two images and return `True` if they are similar enough, or
         `None` if there is an error.
@@ -138,7 +132,9 @@ class LocalBackend(ABC):
         """Indicate whether writing metadata to images is supported."""
         return False
 
-    def write_metadata(self, file: bytes, metadata: Mapping[str, str]) -> None:
+    def write_metadata(
+        self, file: util.PathLike, metadata: Mapping[str, str]
+    ) -> None:
         """Write key-value metadata into the image file.
 
         This must only be called if `self.can_write_metadata()` returns `True`.
@@ -213,11 +209,11 @@ class IMBackend(LocalBackend):
     def resize(
         self,
         maxwidth: int,
-        path_in: bytes,
-        path_out: bytes | None = None,
+        path_in: Path,
+        path_out: Path | None = None,
         quality: int = 0,
         max_filesize: int = 0,
-    ) -> bytes:
+    ) -> Path:
         """Resize using ImageMagick.
 
         Use the ``magick`` program or ``convert`` on older versions. Return
@@ -227,9 +223,7 @@ class IMBackend(LocalBackend):
             path_out = get_temp_filename(__name__, "resize_IM_", path_in)
 
         log.debug(
-            "artresizer: ImageMagick resizing {} to {}",
-            displayable_path(path_in),
-            displayable_path(path_out),
+            "artresizer: ImageMagick resizing {} to {}", path_in, path_out
         )
 
         # "-resize WIDTHx>" shrinks images with the width larger
@@ -239,7 +233,7 @@ class IMBackend(LocalBackend):
         # it here for the sake of explicitness.
         cmd: list[str] = [
             *self.convert_cmd,
-            os.fsdecode(path_in),
+            str(path_in),
             "-resize",
             f"{maxwidth}x>",
             "-interlace",
@@ -254,20 +248,17 @@ class IMBackend(LocalBackend):
         if max_filesize > 0:
             cmd += ["-define", f"jpeg:extent={max_filesize}b"]
 
-        cmd.append(os.fsdecode(path_out))
+        cmd.append(str(path_out))
 
         try:
             util.command_output(cmd)
         except subprocess.CalledProcessError:
-            log.warning(
-                "artresizer: IM convert failed for {}",
-                displayable_path(path_in),
-            )
+            log.warning("artresizer: IM convert failed for {}", path_in)
             return path_in
 
         return path_out
 
-    def get_size(self, path_in: bytes) -> tuple[int, int] | None:
+    def get_size(self, path_in: util.PathLike) -> tuple[int, int] | None:
         cmd: list[str] = [
             *self.identify_cmd,
             "-format",
@@ -299,18 +290,16 @@ class IMBackend(LocalBackend):
 
         return size
 
-    def deinterlace(
-        self, path_in: bytes, path_out: bytes | None = None
-    ) -> bytes:
+    def deinterlace(self, path_in: Path, path_out: Path | None = None) -> Path:
         if not path_out:
             path_out = get_temp_filename(__name__, "deinterlace_IM_", path_in)
 
         cmd = [
             *self.convert_cmd,
-            os.fsdecode(path_in),
+            str(path_in),
             "-interlace",
             "none",
-            os.fsdecode(path_out),
+            str(path_out),
         ]
 
         try:
@@ -320,7 +309,7 @@ class IMBackend(LocalBackend):
             # FIXME: Should probably issue a warning?
             return path_in
 
-    def get_format(self, path_in: bytes) -> str | None:
+    def get_format(self, path_in: util.PathLike) -> str | None:
         cmd = [*self.identify_cmd, "-format", "%[magick]", syspath(path_in)]
 
         try:
@@ -333,8 +322,8 @@ class IMBackend(LocalBackend):
             return None
 
     def convert_format(
-        self, source: bytes, target: bytes, deinterlaced: bool
-    ) -> bytes:
+        self, source: Path, target: Path, deinterlaced: bool
+    ) -> Path:
         cmd = [
             *self.convert_cmd,
             syspath(source),
@@ -356,17 +345,19 @@ class IMBackend(LocalBackend):
         return self.version() > (6, 8, 7)
 
     def compare(
-        self, im1: bytes, im2: bytes, compare_threshold: float
+        self, im1: util.PathLike, im2: util.PathLike, compare_threshold: float
     ) -> bool | None:
         is_windows = platform.system() == "Windows"
 
         # Converting images to grayscale tends to minimize the weight
         # of colors in the diff score. So we first convert both images
         # to grayscale and then pipe them into the `compare` command.
+        im1_path = os.fsdecode(im1)
+        im2_path = os.fsdecode(im2)
         convert_cmd = [
             *self.convert_cmd,
-            os.fsdecode(im2),
-            os.fsdecode(im1),
+            im2_path,
+            im1_path,
             "-colorspace",
             "gray",
             "MIFF:-",
@@ -420,9 +411,7 @@ class IMBackend(LocalBackend):
         if compare_proc.returncode:
             if compare_proc.returncode != 1:
                 log.debug(
-                    "ImageMagick compare failed: {}, {}",
-                    displayable_path(im2),
-                    displayable_path(im1),
+                    "ImageMagick compare failed: {}, {}", im2_path, im1_path
                 )
                 return None
             out_str = stderr
@@ -447,7 +436,9 @@ class IMBackend(LocalBackend):
     def can_write_metadata(self) -> bool:
         return True
 
-    def write_metadata(self, file: bytes, metadata: Mapping[str, str]) -> None:
+    def write_metadata(
+        self, file: util.PathLike, metadata: Mapping[str, str]
+    ) -> None:
         assignments = chain.from_iterable(
             ("-set", k, v) for k, v in metadata.items()
         )
@@ -477,11 +468,11 @@ class PILBackend(LocalBackend):
     def resize(
         self,
         maxwidth: int,
-        path_in: bytes,
-        path_out: bytes | None = None,
+        path_in: Path,
+        path_out: Path | None = None,
         quality: int = 0,
         max_filesize: int = 0,
-    ) -> bytes:
+    ) -> Path:
         """Resize using Python Imaging Library (PIL).  Return the output path
         of resized image.
         """
@@ -490,11 +481,7 @@ class PILBackend(LocalBackend):
 
         from PIL import Image
 
-        log.debug(
-            "artresizer: PIL resizing {} to {}",
-            displayable_path(path_in),
-            displayable_path(path_out),
-        )
+        log.debug("artresizer: PIL resizing {} to {}", path_in, path_out)
 
         try:
             im = Image.open(syspath(path_in))
@@ -507,7 +494,7 @@ class PILBackend(LocalBackend):
 
             # progressive=False only affects JPEGs and is the default,
             # but we include it here for explicitness.
-            im.save(os.fsdecode(path_out), quality=quality, progressive=False)
+            im.save(str(path_out), quality=quality, progressive=False)
 
             if max_filesize > 0:
                 # If maximum filesize is set, we attempt to lower the quality
@@ -531,7 +518,7 @@ class PILBackend(LocalBackend):
                         lower_qual = 10
                     # Use optimize flag to improve filesize decrease
                     im.save(
-                        os.fsdecode(path_out),
+                        path_out,
                         quality=lower_qual,
                         optimize=True,
                         progressive=False,
@@ -543,27 +530,21 @@ class PILBackend(LocalBackend):
 
             return path_out
         except OSError:
-            log.error(
-                "PIL cannot create thumbnail for '{}'",
-                displayable_path(path_in),
-            )
+            log.error("PIL cannot create thumbnail for '{}'", path_in)
             return path_in
 
-    def get_size(self, path_in: bytes) -> tuple[int, int] | None:
+    def get_size(self, path_in: util.PathLike) -> tuple[int, int] | None:
         from PIL import Image
 
+        path = os.fsdecode(path_in)
         try:
-            im = Image.open(syspath(path_in))
+            im = Image.open(path)
             return im.size
         except OSError as exc:
-            log.error(
-                "PIL could not read file {}: {}", displayable_path(path_in), exc
-            )
+            log.error("PIL could not read file {}: {}", path, exc)
             return None
 
-    def deinterlace(
-        self, path_in: bytes, path_out: bytes | None = None
-    ) -> bytes:
+    def deinterlace(self, path_in: Path, path_out: Path | None = None) -> Path:
         if not path_out:
             path_out = get_temp_filename(__name__, "deinterlace_PIL_", path_in)
 
@@ -571,13 +552,13 @@ class PILBackend(LocalBackend):
 
         try:
             im = Image.open(syspath(path_in))
-            im.save(os.fsdecode(path_out), progressive=False)
+            im.save(path_out, progressive=False)
             return path_out
         except OSError:
             # FIXME: Should probably issue a warning?
             return path_in
 
-    def get_format(self, path_in: bytes) -> str | None:
+    def get_format(self, path_in: util.PathLike) -> str | None:
         from PIL import Image, UnidentifiedImageError
 
         try:
@@ -593,8 +574,8 @@ class PILBackend(LocalBackend):
             return None
 
     def convert_format(
-        self, source: bytes, target: bytes, deinterlaced: bool
-    ) -> bytes:
+        self, source: Path, target: Path, deinterlaced: bool
+    ) -> Path:
         from PIL import Image, UnidentifiedImageError
 
         try:
@@ -616,7 +597,7 @@ class PILBackend(LocalBackend):
         return False
 
     def compare(
-        self, im1: bytes, im2: bytes, compare_threshold: float
+        self, im1: util.PathLike, im2: util.PathLike, compare_threshold: float
     ) -> bool | None:
         # It is an error to call this when ArtResizer.can_compare is not True.
         raise NotImplementedError()
@@ -625,7 +606,9 @@ class PILBackend(LocalBackend):
     def can_write_metadata(self) -> bool:
         return True
 
-    def write_metadata(self, file: bytes, metadata: Mapping[str, str]) -> None:
+    def write_metadata(
+        self, file: util.PathLike, metadata: Mapping[str, str]
+    ) -> None:
         from PIL import Image, PngImagePlugin
 
         # FIXME: Detect and handle other file types (currently, the only user
@@ -634,7 +617,7 @@ class PILBackend(LocalBackend):
         meta = PngImagePlugin.PngInfo()
         for k, v in metadata.items():
             meta.add_text(k, v, zip=False)
-        im.save(os.fsdecode(file), "PNG", pnginfo=meta)
+        im.save(file, "PNG", pnginfo=meta)
 
 
 BACKEND_CLASSES: list[type[LocalBackend]] = [IMBackend, PILBackend]
@@ -680,11 +663,11 @@ class ArtResizer:
     def resize(
         self,
         maxwidth: int,
-        path_in: bytes,
-        path_out: bytes | None = None,
+        path_in: Path,
+        path_out: Path | None = None,
         quality: int = 0,
         max_filesize: int = 0,
-    ) -> bytes:
+    ) -> Path:
         """Manipulate an image file according to the method, returning a
         new path. For PIL or IMAGEMAGIC methods, resizes the image to a
         temporary file and encodes with the specified quality level.
@@ -701,9 +684,7 @@ class ArtResizer:
         # Handled by `proxy_url` already.
         return path_in
 
-    def deinterlace(
-        self, path_in: bytes, path_out: bytes | None = None
-    ) -> bytes:
+    def deinterlace(self, path_in: Path, path_out: Path | None = None) -> Path:
         """Deinterlace an image.
 
         Only available locally.
@@ -730,7 +711,7 @@ class ArtResizer:
         """
         return self.local_method is not None
 
-    def get_size(self, path_in: bytes) -> tuple[int, int] | None:
+    def get_size(self, path_in: util.PathLike) -> tuple[int, int] | None:
         """Return the size of an image file as an int couple (width, height)
         in pixels.
 
@@ -742,7 +723,7 @@ class ArtResizer:
             "image cannot be obtained without artresizer backend"
         )
 
-    def get_format(self, path_in: bytes) -> str | None:
+    def get_format(self, path_in: util.PathLike) -> str | None:
         """Returns the format of the image as a string.
 
         Only available locally.
@@ -753,8 +734,8 @@ class ArtResizer:
         return None
 
     def reformat(
-        self, path_in: bytes, new_format: str, deinterlaced: bool = True
-    ) -> bytes:
+        self, path_in: Path, new_format: str, deinterlaced: bool = True
+    ) -> Path:
         """Converts image to desired format, updating its extension, but
         keeping the same filename.
 
@@ -768,8 +749,7 @@ class ArtResizer:
         # A nonexhaustive map of image "types" to extensions overrides
         new_format = {"jpeg": "jpg"}.get(new_format, new_format)
 
-        fname, _ = os.path.splitext(path_in)
-        path_new = fname + b"." + new_format.encode("utf8")
+        path_new = path_in.with_suffix(f".{new_format}")
 
         # allows the exception to propagate, while still making sure a changed
         # file path was removed
@@ -793,7 +773,7 @@ class ArtResizer:
         return False
 
     def compare(
-        self, im1: bytes, im2: bytes, compare_threshold: float
+        self, im1: util.PathLike, im2: util.PathLike, compare_threshold: float
     ) -> bool | None:
         """Return a boolean indicating whether two images are similar.
 
@@ -812,7 +792,9 @@ class ArtResizer:
             return self.local_method.can_write_metadata
         return False
 
-    def write_metadata(self, file: bytes, metadata: Mapping[str, str]) -> None:
+    def write_metadata(
+        self, file: util.PathLike, metadata: Mapping[str, str]
+    ) -> None:
         """Write key-value metadata to the image file.
 
         Only available locally. Currently, expects the image to be a PNG file.

--- a/beetsplug/_utils/art.py
+++ b/beetsplug/_utils/art.py
@@ -4,7 +4,6 @@ music and items' embedded album art.
 
 from __future__ import annotations
 
-import os
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
@@ -15,6 +14,7 @@ from beets.util.artresizer import ArtResizer
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
+    from pathlib import Path
 
     from beets.dbcore import Query
     from beets.library import Album, Item, Library
@@ -23,11 +23,11 @@ if TYPE_CHECKING:
 
 
 def mediafile_image(
-    image_path: bytes, maxwidth: int | None = None
+    image_path: Path, maxwidth: int | None = None
 ) -> mediafile.Image:
     """Return a `mediafile.Image` object for the path."""
 
-    with open(syspath(image_path), "rb") as f:
+    with image_path.open("rb") as f:
         data = f.read()
     return mediafile.Image(data, type=mediafile.ImageType.front)
 
@@ -46,7 +46,7 @@ def get_art(log: Logger, item: Item) -> bytes | None:
 def embed_item(
     log: Logger,
     item: Item,
-    imagepath: bytes,
+    imagepath: Path,
     maxwidth: int | None = None,
     itempath: bytes | None = None,
     compare_threshold: int = 0,
@@ -78,7 +78,7 @@ def embed_item(
 
     # Get the `Image` object from the file.
     try:
-        log.debug("embedding {}", displayable_path(imagepath))
+        log.debug("embedding {}", imagepath)
         image = mediafile_image(imagepath, maxwidth)
     except OSError as exc:
         log.warning("could not read image file: {}", exc)
@@ -103,16 +103,12 @@ def embed_album(
     quality: int = 0,
 ) -> None:
     """Embed album art into all of the album's items."""
-    imagepath = album.artpath
+    imagepath = album.art_filepath
     if not imagepath:
         log.info("No album art present for {}", album)
         return
-    if not os.path.isfile(syspath(imagepath)):
-        log.info(
-            "Album art not found at {} for {}",
-            displayable_path(imagepath),
-            album,
-        )
+    if not imagepath.is_file():
+        log.info("Album art not found at {} for {}", imagepath, album)
         return
     if maxwidth:
         imagepath = resize_image(log, imagepath, maxwidth, quality)
@@ -134,8 +130,8 @@ def embed_album(
 
 
 def resize_image(
-    log: Logger, imagepath: bytes, maxwidth: int, quality: int
-) -> bytes:
+    log: Logger, imagepath: Path, maxwidth: int, quality: int
+) -> Path:
     """Returns path to an image resized to maxwidth and encoded with the
     specified quality level.
     """
@@ -150,7 +146,7 @@ def resize_image(
 def check_art_similarity(
     log: Logger,
     item: Item,
-    imagepath: bytes,
+    imagepath: PathLike,
     compare_threshold: int,
     artresizer: ArtResizer | None = None,
 ) -> bool | None:
@@ -196,7 +192,7 @@ def extract(log: Logger, outpath: PathLike, item: Item) -> bytes | None:
 
 
 def extract_first(
-    log: Logger, outpath: bytes, items: Iterable[Item]
+    log: Logger, outpath: PathLike, items: Iterable[Item]
 ) -> bytes | None:
     for item in items:
         real_path = extract(log, outpath, item)

--- a/beetsplug/bpsync.py
+++ b/beetsplug/bpsync.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Protocol
 
-from beets import library, ui, util
+from beets import library, ui
 from beets.autotag import AlbumMatch, Distance, TrackMatch
 from beets.plugins import BeetsPlugin, apply_item_changes
 from beets.util.deprecation import deprecate_for_user
@@ -198,6 +198,6 @@ class BPSyncPlugin(BeetsPlugin):
                 album.store()
 
                 # Move album art (and any inconsistent items).
-                if move and lib.directory in util.ancestry(items[0].path):
+                if move and lib.is_in_directory(items[0]):
                     self._log.debug("moving album {}", album)
                     album.move()

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 import threading
 from functools import cached_property
+from pathlib import Path
 from string import Template
 from typing import TYPE_CHECKING, Literal, NamedTuple, Protocol
 
@@ -563,15 +564,15 @@ class ConvertPlugin(BeetsPlugin):
 
         if self.config["embed"] and not linked:
             album = item._cached_album
-            if album and album.artpath:
-                maxwidth = self._get_art_resize(album.artpath)
+            if album and (path := album.art_filepath):
+                maxwidth = self._get_art_resize(path)
                 self._log.debug(
                     "embedding album art from {.art_filepath}", album
                 )
                 art.embed_item(
                     self._log,
                     item,
-                    album.artpath,
+                    path,
                     maxwidth,
                     itempath=converted,
                     id3v23=id3v23,
@@ -588,7 +589,7 @@ class ConvertPlugin(BeetsPlugin):
         """Copies or converts the associated cover art of the album. Album must
         have at least one track.
         """
-        if not album or not album.artpath:
+        if not album or not album.artpath or not album.art_filepath:
             return
 
         # The stored art path may point to a missing file (e.g. the cover
@@ -624,29 +625,27 @@ class ConvertPlugin(BeetsPlugin):
             )
             return
 
+        dest_path = Path(os.fsdecode(dest))
         # Decide whether we need to resize the cover-art image.
-        maxwidth = self._get_art_resize(album.artpath)
+        maxwidth = self._get_art_resize(album.art_filepath)
 
         # Either copy or resize (while copying) the image.
         if maxwidth is not None:
             self._log.info(
                 "Resizing cover art from {.art_filepath} to {}",
                 album,
-                util.displayable_path(dest),
+                dest_path,
             )
             if not pretend:
-                ArtResizer.shared.resize(maxwidth, album.artpath, dest)
+                ArtResizer.shared.resize(
+                    maxwidth, album.art_filepath, dest_path
+                )
         else:
             link, hardlink = self.link, self.hardlink
             if pretend:
                 msg = "ln" if hardlink else ("ln -s" if link else "cp")
 
-                self._log.info(
-                    "{} {.art_filepath} {}",
-                    msg,
-                    album,
-                    util.displayable_path(dest),
-                )
+                self._log.info("{} {.art_filepath} {}", msg, album, dest_path)
             else:
                 msg = (
                     "Hardlinking"
@@ -658,7 +657,7 @@ class ConvertPlugin(BeetsPlugin):
                     "{} cover art from {.art_filepath} to {}",
                     msg,
                     album,
-                    util.displayable_path(dest),
+                    dest_path,
                 )
                 if hardlink:
                     util.hardlink(album.artpath, dest)
@@ -763,7 +762,7 @@ class ConvertPlugin(BeetsPlugin):
                 )
                 util.remove(source_path, False)
 
-    def _get_art_resize(self, artpath: bytes) -> int | None:
+    def _get_art_resize(self, artpath: Path) -> int | None:
         """For a given piece of album art, determine whether or not it needs
         to be resized according to the user's settings. If so, returns the
         new size. If not, returns None.

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 from mimetypes import guess_extension
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 import requests
@@ -13,7 +14,7 @@ from beets import config, ui
 from beets.exceptions import UserError
 from beets.plugins import BeetsPlugin
 from beets.ui import print_
-from beets.util import bytestring_path, displayable_path, normpath, syspath
+from beets.util import normpath, syspath
 from beets.util.artresizer import ArtResizer
 from beetsplug._utils import art
 
@@ -127,11 +128,9 @@ class EmbedCoverArtPlugin(BeetsPlugin):
             lib: Library, opts: EmbedArtCLIOpts, args: list[str]
         ) -> None:
             if opts.file:
-                imagepath = normpath(opts.file)
-                if not os.path.isfile(syspath(imagepath)):
-                    raise UserError(
-                        f"image file {displayable_path(imagepath)} not found"
-                    )
+                imagepath = normpath(Path(opts.file))
+                if not imagepath.is_file():
+                    raise UserError(f"image file {imagepath} not found")
 
                 items = lib.items(args)
 
@@ -162,9 +161,9 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     self._log.error("Invalid image file")
                     return
                 file = f"image{extension}"
-                tempimg = os.fsencode(os.path.join(tempfile.gettempdir(), file))
+                tempimg = Path(tempfile.gettempdir()) / file
                 try:
-                    with open(tempimg, "wb") as f:
+                    with tempimg.open("wb") as f:
                         f.write(response.content)
                 except Exception as e:
                     self._log.error("Unable to save image: {}", e)
@@ -172,7 +171,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                 items = lib.items(args)
                 # Confirm with user.
                 if not opts.yes and not _confirm(items, not opts.url):
-                    os.remove(tempimg)
+                    tempimg.unlink()
                     return
                 for item in items:
                     art.embed_item(
@@ -185,7 +184,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                         ifempty,
                         quality=quality,
                     )
-                os.remove(tempimg)
+                tempimg.unlink()
             else:
                 albums = lib.albums(args)
                 # Confirm with user.
@@ -229,13 +228,11 @@ class EmbedCoverArtPlugin(BeetsPlugin):
         ) -> None:
             if opts.outpath:
                 art.extract_first(
-                    self._log, normpath(opts.outpath), lib.items(args)
+                    self._log, Path(opts.outpath), lib.items(args)
                 )
             else:
-                filename = bytestring_path(
-                    opts.filename or config["art_filename"].get()
-                )
-                if os.path.dirname(filename) != b"":
+                filename = Path(opts.filename or config["art_filename"].get())
+                if filename.parent != Path():
                     self._log.error(
                         "Only specify a name rather than a path for -n"
                     )
@@ -243,9 +240,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                 for album in lib.albums(args):
                     if opts.associate and (
                         artpath := art.extract_first(
-                            self._log,
-                            normpath(os.path.join(album.path, filename)),
-                            album.items(),
+                            self._log, album.filepath / filename, album.items()
                         )
                     ):
                         album.set_art(artpath)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 from contextlib import closing
 from enum import Enum
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, AnyStr, ClassVar, Literal, Protocol
 
 import confuse
@@ -17,7 +18,7 @@ from mediafile import image_mime_type
 
 from beets import config, importer, plugins, ui, util
 from beets.exceptions import UserError
-from beets.util import bytestring_path, get_temp_filename, sorted_walk, syspath
+from beets.util import get_temp_filename, sorted_walk, syspath
 from beets.util.artresizer import ArtResizer
 from beets.util.color import colorize
 from beets.util.config import UnknownPairError, sanitize_pairs
@@ -44,9 +45,9 @@ except ImportError:
 
 
 CONTENT_TYPES = {
-    "image/jpeg": [b"jpg", b"jpeg"],
-    "image/png": [b"png"],
-    "image/webp": [b"webp"],
+    "image/jpeg": ["jpg", "jpeg"],
+    "image/png": ["png"],
+    "image/webp": ["webp"],
 }
 IMAGE_EXTENSIONS = [ext for exts in CONTENT_TYPES.values() for ext in exts]
 
@@ -81,7 +82,7 @@ class Candidate:
         self,
         log: Logger,
         source_name: str,
-        path: bytes | None = None,
+        path: Path | None = None,
         url: str | None = None,
         match: MetadataMatch | None = None,
         size: tuple[int, int] | None = None,
@@ -195,7 +196,7 @@ class Candidate:
         # Check filesize.
         downsize = False
         if plugin.max_filesize:
-            filesize = os.stat(syspath(self.path)).st_size
+            filesize = self.path.stat().st_size
             if filesize > plugin.max_filesize:
                 self._log.debug(
                     "image needs resizing ({}B > {.max_filesize}B)",
@@ -388,10 +389,7 @@ class ArtSource(RequestMixin, ABC):
 
     @abstractmethod
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         pass
 
@@ -474,7 +472,7 @@ class RemoteArtSource(ArtSource):
                     )
                     return
 
-                ext = b"." + CONTENT_TYPES[real_ct][0]
+                ext = f".{CONTENT_TYPES[real_ct][0]}"
 
                 if real_ct != ct:
                     self._log.warning(
@@ -486,17 +484,15 @@ class RemoteArtSource(ArtSource):
                         ext,
                     )
 
-                filename = get_temp_filename(__name__, suffix=ext.decode())
-                with open(filename, "wb") as fh:
+                filename = get_temp_filename(__name__, suffix=ext)
+                with filename.open("wb") as fh:
                     # write the first already loaded part of the image
                     fh.write(header)
                     # download the remaining part of the image
                     for chunk in data:
                         fh.write(chunk)
-                self._log.debug(
-                    "downloaded art to: {}", util.displayable_path(filename)
-                )
-                candidate.path = util.bytestring_path(filename)
+                self._log.debug("downloaded art to: {}", filename)
+                candidate.path = filename
                 return
 
         except (OSError, requests.RequestException, TypeError) as exc:
@@ -527,10 +523,7 @@ class CoverArtArchive(RemoteArtSource):
     GROUP_URL = "https://coverartarchive.org/release-group/{mbid}"
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         """Return the Cover Art Archive and Cover Art Archive release
         group URLs using album MusicBrainz release ID and release group
@@ -604,10 +597,7 @@ class Amazon(RemoteArtSource):
     INDICES = (1, 2)
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         """Generate URLs using Amazon ID (ASIN) string."""
         if album.asin:
@@ -625,10 +615,7 @@ class AlbumArtOrg(RemoteArtSource):
     PAT = r'href\s*=\s*"([^>"]*)"[^>]*title\s*=\s*"View larger image"'
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Any]:
         """Return art URL from AlbumArt.org using album ASIN."""
         if not album.asin:
@@ -679,10 +666,7 @@ class GoogleImages(RemoteArtSource):
         return has_key
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         """Return art URL from google custom search engine
         given an album title and interpreter.
@@ -743,10 +727,7 @@ class FanartTV(RemoteArtSource):
         config["fanarttv_key"].redact = True
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         if not album.mb_releasegroupid:
             return
@@ -813,10 +794,7 @@ class ITunesStore(RemoteArtSource):
     API_URL = "https://itunes.apple.com/search"
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         """Return art URL from iTunes Store given an album title."""
         if not (album.albumartist and album.album):
@@ -919,10 +897,7 @@ class Wikipedia(RemoteArtSource):
                  Limit 1"""
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         if not (album.albumartist and album.album):
             return
@@ -1056,17 +1031,14 @@ class FileSystem(LocalArtSource):
         return [idx for (idx, x) in enumerate(cover_names) if x in filename]
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         """Look for album art files in the specified directories."""
         if not paths:
             return
-        cover_names = list(map(util.bytestring_path, plugin.cover_names))
-        cover_names_str = b"|".join(cover_names)
-        cover_pat = rb"".join([rb"(\b|_)(", cover_names_str, rb")(\b|_)"])
+        cover_names = plugin.cover_names
+        cover_names_str = "|".join(cover_names)
+        cover_pat = rf"(\b|_)({cover_names_str})(\b|_)"
 
         for path in paths:
             if not os.path.isdir(syspath(path)):
@@ -1074,17 +1046,15 @@ class FileSystem(LocalArtSource):
 
             # Find all files that look like images in the directory.
             images = []
-            ignore = list(map(os.fsencode, config["ignore"].as_str_seq()))
+            ignore = config["ignore"].as_str_seq()
             ignore_hidden = config["ignore_hidden"].get(bool)
             for _, _, files in sorted_walk(
-                path, ignore=ignore, ignore_hidden=ignore_hidden
+                str(path), ignore=ignore, ignore_hidden=ignore_hidden
             ):
                 for fn in files:
-                    fn = bytestring_path(fn)
+                    fn_path = path / fn
                     for ext in IMAGE_EXTENSIONS:
-                        if fn.lower().endswith(b"." + ext) and os.path.isfile(
-                            syspath(os.path.join(path, fn))
-                        ):
+                        if fn_path.suffix == f".{ext}" and fn_path.is_file():
                             images.append(fn)
 
             # Look for "preferred" filenames.
@@ -1094,22 +1064,16 @@ class FileSystem(LocalArtSource):
             remaining = []
             for fn in images:
                 if re.search(cover_pat, os.path.splitext(fn)[0], re.I):
-                    self._log.debug(
-                        "using well-named art file {}",
-                        util.displayable_path(fn),
-                    )
+                    self._log.debug("using well-named art file {}", fn)
                     yield self._candidate(
-                        path=os.path.join(path, fn), match=MetadataMatch.EXACT
+                        path=path / fn, match=MetadataMatch.EXACT
                     )
                 else:
                     remaining.append(fn)
 
             # Fall back to a configured image.
             if plugin.fallback:
-                self._log.debug(
-                    "using fallback art file {}",
-                    util.displayable_path(plugin.fallback),
-                )
+                self._log.debug("using fallback art file {}", plugin.fallback)
                 yield self._candidate(
                     path=plugin.fallback, match=MetadataMatch.FALLBACK
                 )
@@ -1121,8 +1085,7 @@ class FileSystem(LocalArtSource):
                     util.displayable_path(remaining[0]),
                 )
                 yield self._candidate(
-                    path=os.path.join(path, remaining[0]),
-                    match=MetadataMatch.FALLBACK,
+                    path=path / remaining[0], match=MetadataMatch.FALLBACK
                 )
 
 
@@ -1160,10 +1123,7 @@ class LastFM(RemoteArtSource):
         return has_key
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         if not album.mb_albumid:
             return
@@ -1230,10 +1190,7 @@ class Spotify(RemoteArtSource):
         return HAS_BEAUTIFUL_SOUP
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         try:
             url = f"{self.SPOTIFY_ALBUM_URL}{album.items().get().spotify_album_id}"  # type: ignore[union-attr]
@@ -1278,10 +1235,7 @@ class CoverArtUrl(RemoteArtSource):
     ID = "cover_art_url"
 
     def get(
-        self,
-        album: Album,
-        plugin: FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        self, album: Album, plugin: FetchArtPlugin, paths: Sequence[Path] | None
     ) -> Iterator[Candidate]:
         image_url = None
         try:
@@ -1389,10 +1343,10 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             self.enforce_ratio = True
 
         cover_names = self.config["cover_names"].as_str_seq()
-        self.cover_names = list(map(util.bytestring_path, cover_names))
+        self.cover_names = cover_names
         self.cautious = self.config["cautious"].get(bool)
         self.fallback = self.config["fallback"].get(
-            confuse.Optional(confuse.Filename())
+            confuse.Optional(confuse.templates.Path())
         )
         self.store_source = self.config["store_source"].get(bool)
 
@@ -1470,7 +1424,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             return (
                 candidate.path is not None
                 and self.fallback is not None
-                and os.path.samefile(candidate.path, self.fallback)
+                and candidate.path.samefile(self.fallback)
             )
         except OSError:
             return False
@@ -1498,7 +1452,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 # For any other choices (e.g., TRACKS), do nothing.
                 return
 
-            candidate = self.art_for_album(task.album, task.paths, local)
+            paths = [Path(os.fsdecode(p)) for p in task.paths]
+            candidate = self.art_for_album(task.album, paths, local)
 
             if candidate:
                 self.art_candidates[task] = candidate
@@ -1575,7 +1530,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
     def art_for_album(
         self,
         album: Album,
-        paths: Sequence[bytes] | None,
+        paths: Sequence[Path] | None,
         local_only: bool = False,
     ) -> Candidate | None:
         """Given an Album object, returns a path to downloaded art for the
@@ -1635,7 +1590,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 # In ordinary invocations, look for images on the
                 # filesystem. When forcing, however, always go to the Web
                 # sources.
-                local_paths = None if force else [album.path]
+                local_paths = None if force else [album.filepath]
 
                 candidate = self.art_for_album(album, local_paths)
                 if candidate:

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -10,7 +10,7 @@ from contextlib import closing
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AnyStr, ClassVar, Literal, Protocol
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol
 
 import confuse
 import requests
@@ -18,7 +18,7 @@ from mediafile import image_mime_type
 
 from beets import config, importer, plugins, ui, util
 from beets.exceptions import UserError
-from beets.util import get_temp_filename, sorted_walk, syspath
+from beets.util import get_temp_filename, sorted_walk
 from beets.util.artresizer import ArtResizer
 from beets.util.color import colorize
 from beets.util.config import UnknownPairError, sanitize_pairs
@@ -49,7 +49,7 @@ CONTENT_TYPES = {
     "image/png": ["png"],
     "image/webp": ["webp"],
 }
-IMAGE_EXTENSIONS = [ext for exts in CONTENT_TYPES.values() for ext in exts]
+IMAGE_EXTENSIONS = [f".{e}" for exts in CONTENT_TYPES.values() for e in exts]
 
 
 class ImageAction(Enum):
@@ -1020,7 +1020,7 @@ class FileSystem(LocalArtSource):
 
     @staticmethod
     def filename_priority(
-        filename: AnyStr, cover_names: Sequence[AnyStr]
+        filename: str, cover_names: Sequence[str]
     ) -> list[int]:
         """Sort order for image names.
 
@@ -1037,55 +1037,55 @@ class FileSystem(LocalArtSource):
         if not paths:
             return
         cover_names = plugin.cover_names
-        cover_names_str = "|".join(cover_names)
-        cover_pat = rf"(\b|_)({cover_names_str})(\b|_)"
+        cover_names_str = "|".join(map(re.escape, cover_names))
+        cover_pat = re.compile(rf"(\b|_)({cover_names_str})(\b|_)", re.I)
 
         for path in paths:
-            if not os.path.isdir(syspath(path)):
+            if not path.is_dir():
                 continue
 
             # Find all files that look like images in the directory.
-            images = []
             ignore = config["ignore"].as_str_seq()
             ignore_hidden = config["ignore_hidden"].get(bool)
-            for _, _, files in sorted_walk(
-                str(path), ignore=ignore, ignore_hidden=ignore_hidden
-            ):
-                for fn in files:
-                    fn_path = path / fn
-                    for ext in IMAGE_EXTENSIONS:
-                        if fn_path.suffix == f".{ext}" and fn_path.is_file():
-                            images.append(fn)
+            images = [
+                fn_path
+                for root, _, files in sorted_walk(
+                    str(path), ignore=ignore, ignore_hidden=ignore_hidden
+                )
+                for fn in files
+                if (
+                    (fn_path := Path(path) / fn).suffix.lower()
+                    in IMAGE_EXTENSIONS
+                )
+                and fn_path.is_file()
+            ]
 
             # Look for "preferred" filenames.
-            images = sorted(
-                images, key=lambda x: self.filename_priority(x, cover_names)
+            images.sort(
+                key=lambda p: self.filename_priority(p.name, cover_names)
             )
             remaining = []
-            for fn in images:
-                if re.search(cover_pat, os.path.splitext(fn)[0], re.I):
-                    self._log.debug("using well-named art file {}", fn)
+            for fn_path in images:
+                if cover_pat.search(name := fn_path.name):
+                    self._log.debug("using well-named art file {}", name)
                     yield self._candidate(
-                        path=path / fn, match=MetadataMatch.EXACT
+                        path=fn_path, match=MetadataMatch.EXACT
                     )
                 else:
-                    remaining.append(fn)
+                    remaining.append(fn_path)
 
             # Fall back to a configured image.
-            if plugin.fallback:
-                self._log.debug("using fallback art file {}", plugin.fallback)
+            if fallback := plugin.fallback:
+                self._log.debug("using fallback art file {}", fallback)
                 yield self._candidate(
-                    path=plugin.fallback, match=MetadataMatch.FALLBACK
+                    path=fallback, match=MetadataMatch.FALLBACK
                 )
 
             # Fall back to any image in the folder.
             if remaining and not plugin.cautious:
-                self._log.debug(
-                    "using fallback art file {}",
-                    util.displayable_path(remaining[0]),
-                )
+                self._log.debug("using fallback art file {}", remaining[0])
                 yield self._candidate(
-                    path=path / remaining[0], match=MetadataMatch.FALLBACK
+                    path=remaining[0], match=MetadataMatch.FALLBACK
                 )
 
 
@@ -1433,9 +1433,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
     def fetch_art(self, session: ImportSession, task: ImportTask) -> None:
         """Find art for the album being imported."""
         if task.is_album:  # Only fetch art for full albums.
-            if task.album.artpath and os.path.isfile(
-                syspath(task.album.artpath)
-            ):
+            if task.album.art_filepath and task.album.art_filepath.is_file():
                 # Album already has art (probably a re-import); skip it.
                 return
             if task.choice_flag == importer.Action.ASIS:
@@ -1579,9 +1577,9 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         """
         for album in albums:
             if (
-                album.artpath
-                and not force
-                and os.path.isfile(syspath(album.artpath))
+                not force
+                and album.art_filepath
+                and album.art_filepath.is_file()
             ):
                 if not quiet:
                     message = colorize("text_highlight_minor", "has album art")

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Protocol
 
@@ -301,7 +302,7 @@ class IPFSPlugin(BeetsPlugin):
     def ipfs_added_albums(self, rlib: Library, tmpname: str) -> Library:
         """Returns a new library with only albums/items added to ipfs"""
         tmplib = library.Library(
-            tmpname, directory="/ipfs/", set_music_dir=False
+            tmpname, directory=Path("/ipfs/"), set_music_dir=False
         )
         with tmplib.music_dir_context():
             for album in rlib.albums():

--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Protocol
 
-from beets import library, metadata_plugins, ui, util
+from beets import library, metadata_plugins, ui
 from beets.autotag import AlbumMatch, Distance, TrackMatch
 from beets.plugins import BeetsPlugin, apply_item_changes
 
@@ -198,6 +198,6 @@ class MBSyncPlugin(BeetsPlugin):
                     album.store()
 
                     # Move album art (and any inconsistent items).
-                    if move and lib.directory in util.ancestry(items[0].path):
+                    if move and lib.is_in_directory(items[0]):
                         self._log.debug("moving album {}", album)
                         album.move()

--- a/beetsplug/permissions.py
+++ b/beetsplug/permissions.py
@@ -8,16 +8,15 @@ like the following in your config.yaml to configure:
 
 from __future__ import annotations
 
-import os
 import stat
 from typing import TYPE_CHECKING
 
 from beets import config
 from beets.plugins import BeetsPlugin
-from beets.util import ancestry, displayable_path, syspath
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from pathlib import Path
 
     from beets.library import Album, Item, Library
     from beets.logging import BeetsLogger as Logger
@@ -33,32 +32,34 @@ def convert_perm(perm: str | int) -> int:
     return int(perm, 8)
 
 
-def check_permissions(path: bytes, permission: int) -> bool:
+def check_permissions(path: Path, permission: int) -> bool:
     """Check whether the file's permissions equal the given vector.
     Return a boolean.
     """
-    return oct(stat.S_IMODE(os.stat(syspath(path)).st_mode)) == oct(permission)
+    return oct(stat.S_IMODE(path.stat().st_mode)) == oct(permission)
 
 
-def assert_permissions(path: bytes, permission: int, log: Logger) -> None:
+def assert_permissions(path: Path, permission: int, log: Logger) -> None:
     """Check whether the file's permissions are as expected, otherwise,
     log a warning message. Return a boolean indicating the match, like
     `check_permissions`.
     """
     if not check_permissions(path, permission):
-        log.warning("could not set permissions on {}", displayable_path(path))
+        log.warning("could not set permissions on {}", path)
         log.debug(
             "set permissions to {}, but permissions are now {}",
             permission,
-            os.stat(syspath(path)).st_mode & 0o777,
+            path.stat().st_mode & 0o777,
         )
 
 
-def dirs_in_library(library: bytes, path: bytes) -> list[bytes]:
+def dirs_in_library(library: Path, path: Path) -> list[Path]:
     """Creates a list of ancestor directories in the beets library path."""
-    return [
-        ancestor for ancestor in ancestry(path) if ancestor.startswith(library)
-    ][1:]
+    if not path.is_relative_to(library):
+        return []
+
+    exclude = {library, *library.parents}
+    return [p for p in path.parents if p not in exclude]
 
 
 class Permissions(BeetsPlugin):
@@ -74,26 +75,27 @@ class Permissions(BeetsPlugin):
 
     def fix_item(self, lib: Library, item: Item) -> None:
         self.set_permissions(
-            files=[item.path], dirs=dirs_in_library(lib.directory, item.path)
+            files=[item.filepath],
+            dirs=dirs_in_library(lib.directory, item.filepath),
         )
 
     def fix_album(self, lib: Library, album: Album) -> None:
-        files: list[bytes] = []
-        dirs: set[bytes] = set()
+        files: list[Path] = []
+        dirs: set[Path] = set()
         for item in album.items():
-            files.append(item.path)
-            dirs.update(dirs_in_library(lib.directory, item.path))
+            files.append(item.filepath)
+            dirs.update(dirs_in_library(lib.directory, item.filepath))
         self.set_permissions(files=files, dirs=dirs)
 
     def fix_art(self, album: Album) -> None:
         """Fix the permission for Album art file."""
-        if album.artpath:
-            self.set_permissions(files=[album.artpath])
+        if album.art_filepath:
+            self.set_permissions(files=[album.art_filepath])
 
     def set_permissions(
         self,
-        files: Iterable[bytes] | None = None,
-        dirs: Iterable[bytes] | None = None,
+        files: Iterable[Path] | None = None,
+        dirs: Iterable[Path] | None = None,
     ) -> None:
         # Get the configured permissions. The user can specify this either a
         # string (in YAML quotes) or, for convenience, as an integer so the
@@ -106,11 +108,9 @@ class Permissions(BeetsPlugin):
 
         for path in files or []:
             # Changing permissions on the destination file.
-            self._log.debug(
-                "setting file permissions on {}", displayable_path(path)
-            )
+            self._log.debug("setting file permissions on {}", path)
             if not check_permissions(path, file_perm):
-                os.chmod(syspath(path), file_perm)
+                path.chmod(file_perm)
 
             # Checks if the destination path has the permissions configured.
             assert_permissions(path, file_perm, self._log)
@@ -118,11 +118,9 @@ class Permissions(BeetsPlugin):
         # Change permissions for the directories.
         for path in dirs or []:
             # Changing permissions on the destination directory.
-            self._log.debug(
-                "setting directory permissions on {}", displayable_path(path)
-            )
+            self._log.debug("setting directory permissions on {}", path)
             if not check_permissions(path, dir_perm):
-                os.chmod(syspath(path), dir_perm)
+                path.chmod(dir_perm)
 
             # Checks if the destination path has the permissions configured.
             assert_permissions(path, dir_perm, self._log)

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import random
 import shlex
 import subprocess
@@ -154,15 +155,12 @@ class PlayPlugin(BeetsPlugin):
             random.shuffle(paths)
 
         open_args = self._playlist_or_paths(paths)
-        open_args_str = [
-            p.decode("utf-8") for p in self._playlist_or_paths(paths)
-        ]
         command_str = self._command_str(opts.args)
 
         if PLS_MARKER in command_str:
             if not config["play"]["raw"]:
                 command_str = command_str.replace(
-                    PLS_MARKER, "".join(open_args_str)
+                    PLS_MARKER, "".join(map(str, open_args))
                 )
                 self._log.debug(
                     "command altered by PLS_MARKER to: {}", command_str
@@ -230,14 +228,14 @@ class PlayPlugin(BeetsPlugin):
         """Create a temporary .m3u file. Return the filename."""
         utf8_bom = config["play"]["bom"].get(bool)
         filename = get_temp_filename(__name__, suffix=".m3u")
-        with open(filename, "wb") as m3u:
+        with filename.open("wb") as m3u:
             if utf8_bom:
                 m3u.write(b"\xef\xbb\xbf")
 
             for item in paths_list:
                 m3u.write(item + b"\n")
 
-        return filename
+        return os.fsencode(filename)
 
     def before_choose_candidate_listener(
         self, session: ImportSession, task: ImportTask

--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -14,22 +14,23 @@ from hashlib import md5
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
-from xdg import BaseDirectory
+import platformdirs
 
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
-from beets.util import bytestring_path, displayable_path, syspath
 from beets.util.artresizer import ArtResizer
 
-BASE_DIR = os.path.join(BaseDirectory.xdg_cache_home, "thumbnails")
 if TYPE_CHECKING:
     import optparse
+    from pathlib import Path
 
     from beets.library import Album, Library
+    from beets.util import StrPath
 
 
-NORMAL_DIR = bytestring_path(os.path.join(BASE_DIR, "normal"))
-LARGE_DIR = bytestring_path(os.path.join(BASE_DIR, "large"))
+BASE_DIR = platformdirs.user_cache_path() / "thumbnails"
+NORMAL_DIR = BASE_DIR / "normal"
+LARGE_DIR = BASE_DIR / "large"
 
 
 class ThumbnailsPlugin(BeetsPlugin):
@@ -87,8 +88,7 @@ class ThumbnailsPlugin(BeetsPlugin):
             return False
 
         for dir_ in (NORMAL_DIR, LARGE_DIR):
-            if not os.path.exists(syspath(dir_)):
-                os.makedirs(syspath(dir_))
+            dir_.mkdir(parents=True, exist_ok=True)
 
         if not ArtResizer.shared.can_write_metadata:
             raise RuntimeError(
@@ -109,13 +109,13 @@ class ThumbnailsPlugin(BeetsPlugin):
         """Produce thumbnails for the album folder."""
         self._log.debug("generating thumbnail for {}", album)
 
-        artpath = album.artpath
+        artpath = album.art_filepath
         if not artpath:
             self._log.warning("album {} has no art", album)
             return
 
         if self.config["dolphin"]:
-            self.make_dolphin_cover_thumbnail(album.path, artpath)
+            self.make_dolphin_cover_thumbnail(album.filepath, artpath)
 
         size = ArtResizer.shared.get_size(artpath)
         if not size:
@@ -135,18 +135,14 @@ class ThumbnailsPlugin(BeetsPlugin):
             self._log.info("nothing to do for {}", album)
 
     def make_cover_thumbnail(
-        self, album: Album, artpath: bytes, size: int, target_dir: bytes
+        self, album: Album, artpath: Path, size: int, target_dir: Path
     ) -> bool:
         """Make a thumbnail of given size for `album` and put it in
         `target_dir`.
         """
-        target = os.path.join(target_dir, self.thumbnail_file_name(album.path))
+        target = target_dir / self.thumbnail_file_name(album.filepath)
 
-        if (
-            os.path.exists(syspath(target))
-            and os.stat(syspath(target)).st_mtime
-            > os.stat(syspath(artpath)).st_mtime
-        ):
+        if target.exists() and target.stat().st_mtime > artpath.stat().st_mtime:
             if self.config["force"]:
                 self._log.debug(
                     "found a suitable {0}x{0} thumbnail for {1}, "
@@ -163,22 +159,22 @@ class ThumbnailsPlugin(BeetsPlugin):
                 return False
         resized = ArtResizer.shared.resize(size, artpath, target)
         self.add_tags(artpath, resized)
-        shutil.move(syspath(resized), syspath(target))
+        shutil.move(resized, target)
         return True
 
-    def thumbnail_file_name(self, path: bytes) -> bytes:
+    def thumbnail_file_name(self, path: Path) -> str:
         """Compute the thumbnail file name
         See https://standards.freedesktop.org/thumbnail-spec/latest/x227.html
         """
         uri = self.get_uri(path)
         hash_ = md5(uri.encode("utf-8")).hexdigest()
-        return bytestring_path(f"{hash_}.png")
+        return f"{hash_}.png"
 
-    def add_tags(self, artpath: bytes, image_path: bytes) -> None:
+    def add_tags(self, artpath: Path, image_path: Path) -> None:
         """Write required metadata to the thumbnail
         See https://standards.freedesktop.org/thumbnail-spec/latest/x142.html
         """
-        mtime = os.stat(syspath(artpath)).st_mtime
+        mtime = artpath.stat().st_mtime
         metadata = {
             "Thumb::URI": self.get_uri(artpath),
             "Thumb::MTime": str(mtime),
@@ -186,29 +182,27 @@ class ThumbnailsPlugin(BeetsPlugin):
         try:
             ArtResizer.shared.write_metadata(image_path, metadata)
         except Exception:
-            self._log.exception(
-                "could not write metadata to {}", displayable_path(image_path)
-            )
+            self._log.exception("could not write metadata to {}", image_path)
 
     def make_dolphin_cover_thumbnail(
-        self, album_path: bytes, artpath: bytes
+        self, album_path: Path, artpath: Path
     ) -> None:
-        outfilename = os.path.join(album_path, b".directory")
-        if os.path.exists(syspath(outfilename)):
+        outfilename = album_path / ".directory"
+        if outfilename.exists():
             return
-        artfile = os.path.split(artpath)[1]
-        with open(syspath(outfilename), "w") as f:
+        artfile = artpath.name
+        with outfilename.open("w") as f:
             f.write("[Desktop Entry]\n")
-            f.write(f"Icon=./{artfile.decode('utf-8')}")
+            f.write(f"Icon=./{artfile}")
             f.close()
-        self._log.debug("Wrote file {}", displayable_path(outfilename))
+        self._log.debug("Wrote file {}", outfilename)
 
 
 class URIGetter:
     available = False
     name = "Abstract base"
 
-    def uri(self, path: bytes) -> str:
+    def uri(self, path: StrPath) -> str:
         raise NotImplementedError()
 
 
@@ -216,8 +210,8 @@ class PathlibURI(URIGetter):
     available = True
     name = "Python Pathlib"
 
-    def uri(self, path: bytes) -> str:
-        return PurePosixPath(os.fsdecode(path)).as_uri()
+    def uri(self, path: StrPath) -> str:
+        return PurePosixPath(path).as_uri()
 
 
 def copy_c_string(c_string: Any) -> bytes | None:
@@ -258,16 +252,14 @@ class GioURI(URIGetter):
         except OSError:
             return None
 
-    def uri(self, path: bytes) -> str:
+    def uri(self, path: StrPath) -> str:
         libgio = self.libgio
         if libgio is None:
             raise RuntimeError("GIO library is unavailable")
 
-        g_file_ptr = libgio.g_file_new_for_path(path)
+        g_file_ptr = libgio.g_file_new_for_path(os.fsencode(path))
         if not g_file_ptr:
-            raise RuntimeError(
-                f"No gfile pointer received for {displayable_path(path)}"
-            )
+            raise RuntimeError(f"No gfile pointer received for {path}")
 
         try:
             uri_ptr = libgio.g_file_get_uri(g_file_ptr)
@@ -276,7 +268,7 @@ class GioURI(URIGetter):
         if not uri_ptr:
             libgio.g_free(uri_ptr)
             raise RuntimeError(
-                f"No URI received from the gfile pointer for {displayable_path(path)}"
+                f"No URI received from the gfile pointer for {path}"
             )
 
         try:

--- a/beetsplug/unimported.py
+++ b/beetsplug/unimported.py
@@ -6,9 +6,9 @@ List all files in the library folder which are not listed in the
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from beets import util
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, print_
 
@@ -30,29 +30,28 @@ class Unimported(BeetsPlugin):
         def print_unimported(
             lib: Library, opts: optparse.Values, args: list[str]
         ) -> None:
-            ignore_exts = [
-                f".{x}".encode()
-                for x in self.config["ignore_extensions"].as_str_seq()
-            ]
-            ignore_dirs = [
-                os.path.join(lib.directory, x.encode())
+            ignore_exts = {
+                f".{x}" for x in self.config["ignore_extensions"].as_str_seq()
+            }
+            ignore_dirs = {
+                lib.directory / x
                 for x in self.config["ignore_subdirectories"].as_str_seq()
-            ]
-            in_folder = set()
-            for root, _, files in os.walk(lib.directory):
-                # do not traverse if root is a child of an ignored directory
-                if any(root.startswith(ignored) for ignored in ignore_dirs):
-                    continue
-                for file in files:
-                    # ignore files with ignored extensions
-                    if any(file.endswith(ext) for ext in ignore_exts):
-                        continue
-                    in_folder.add(os.path.join(root, file))
+            }
 
-            in_library = {x.path for x in lib.items()}
-            art_files = {x.artpath for x in lib.albums()}
-            for f in in_folder - in_library - art_files:
-                print_(util.displayable_path(f))
+            ignored: set[Path | None] = set()
+            ignored.update(x.filepath for x in lib.items())
+            ignored.update(x.art_filepath for x in lib.albums())
+            for root, _, files in os.walk(lib.directory):
+                root_path = Path(root)
+                # do not traverse if root is a child of an ignored directory
+                if {*root_path.parents, root_path} & ignore_dirs:
+                    continue
+                for file in map(Path, files):
+                    # ignore files with ignored extensions
+                    if file.suffix in ignore_exts:
+                        continue
+                    if (_path := (root_path / file)) not in ignored:
+                        print_(str(_path))
 
         unimported = Subcommand(
             "unimported",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "colorama ; sys_platform == 'win32'",
-    "confuse>=2.2.0",
+    "confuse>=2.2.1",
     "jellyfish",
     "lap>=0.5.12",
     "mediafile>=0.17.0",

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -56,7 +55,7 @@ class DummyRemoteArtSource(fetchart.RemoteArtSource):
         self,
         album,
         plugin: fetchart.FetchArtPlugin,
-        paths: Sequence[bytes] | None,
+        paths: Sequence[Path] | None,
     ) -> Iterator[fetchart.Candidate]:
         return iter(())
 
@@ -89,10 +88,10 @@ class UseThePlugin(TestHelper):
                 clean_module_tempdir(module)
 
     @pytest.fixture
-    def dpath(self) -> bytes:
+    def dpath(self) -> Path:
         dpath = self.temp_path / "arttest"
         dpath.mkdir()
-        return os.fsencode(dpath)
+        return dpath
 
 
 class CAAData:
@@ -249,8 +248,8 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
         image_request_mock.get(self.URL, content_type="image/png")
         source.fetch_image(candidate, settings)
         assert candidate.path is not None
-        assert os.path.splitext(candidate.path)[1] == b".png"
-        assert Path(os.fsdecode(candidate.path)).exists()
+        assert candidate.path.suffix == ".png"
+        assert candidate.path.exists()
 
     def test_does_not_rely_on_server_content_type(
         self, source, candidate, settings, image_request_mock
@@ -260,8 +259,8 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
         )
         source.fetch_image(candidate, settings)
         assert candidate.path is not None
-        assert os.path.splitext(candidate.path)[1] == b".png"
-        assert Path(os.fsdecode(candidate.path)).exists()
+        assert candidate.path.suffix == ".png"
+        assert candidate.path.exists()
 
 
 class TestFSArt(UseThePlugin):
@@ -274,27 +273,29 @@ class TestFSArt(UseThePlugin):
         return fetchart.FileSystem(logger, self.plugin.config)
 
     def test_finds_jpg_in_directory(self, source, dpath, settings) -> None:
-        _common.touch(os.path.join(dpath, b"a.jpg"))
+        candidate_path = dpath / "a.jpg"
+        candidate_path.touch()
         candidate = next(source.get(Album(), settings, [dpath]))
-        assert candidate.path == os.path.join(dpath, b"a.jpg")
+        assert candidate.path == candidate_path
 
     def test_appropriately_named_file_takes_precedence(
         self, source, dpath, settings
     ) -> None:
-        _common.touch(os.path.join(dpath, b"a.jpg"))
-        _common.touch(os.path.join(dpath, b"art.jpg"))
+        (dpath / "a.jpg").touch()
+        candidate_path = dpath / "art.jpg"
+        candidate_path.touch()
         candidate = next(source.get(Album(), settings, [dpath]))
-        assert candidate.path == os.path.join(dpath, b"art.jpg")
+        assert candidate.path == candidate_path
 
     def test_non_image_file_not_identified(
         self, source, dpath, settings
     ) -> None:
-        _common.touch(os.path.join(dpath, b"a.txt"))
+        (dpath / "a.txt").touch()
         with pytest.raises(StopIteration):
             next(source.get(Album(), settings, [dpath]))
 
     def test_cautious_skips_fallback(self, source, dpath, settings) -> None:
-        _common.touch(os.path.join(dpath, b"a.jpg"))
+        (dpath / "a.jpg").touch()
         settings.cautious = True
         with pytest.raises(StopIteration):
             next(source.get(Album(), settings, [dpath]))
@@ -313,25 +314,25 @@ class TestFSArt(UseThePlugin):
     def test_precedence_amongst_correct_files(
         self, source, dpath, settings
     ) -> None:
-        images = [b"front-cover.jpg", b"front.jpg", b"back.jpg"]
-        paths = [os.path.join(dpath, i) for i in images]
+        images = ["front-cover.jpg", "front.jpg", "back.jpg"]
+        paths = [dpath / i for i in images]
         for p in paths:
-            _common.touch(p)
-        settings.cover_names = [b"cover", b"front", b"back"]
+            p.touch()
+        settings.cover_names = ["cover", "front", "back"]
         candidates = [
             candidate.path
             for candidate in source.get(Album(), settings, [dpath])
         ]
         assert candidates == paths
 
-    @patch("os.path.samefile")
+    @patch("pathlib.Path.samefile")
     def test_is_candidate_fallback_os_error(
         self, mock_samefile, source
     ) -> None:
         mock_samefile.side_effect = OSError("os error")
         fallback = self.temp_path / "a.jpg"
         self.plugin.fallback = str(fallback)
-        candidate = fetchart.Candidate(logger, source.ID, os.fsencode(fallback))
+        candidate = fetchart.Candidate(logger, source.ID, fallback)
         result = self.plugin._is_candidate_fallback(candidate)
         mock_samefile.assert_called_once()
         assert not result
@@ -358,12 +359,13 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
     def test_main_interface_gives_precedence_to_fs_art(
         self, dpath, image_request_mock
     ):
-        _common.touch(os.path.join(dpath, b"art.jpg"))
+        candidate_path = dpath / "art.jpg"
+        candidate_path.touch()
         image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [dpath])
         assert candidate is not None
-        assert candidate.path == os.path.join(dpath, b"art.jpg")
+        assert candidate.path == candidate_path
 
     def test_main_interface_falls_back_to_amazon(
         self, dpath, image_request_mock
@@ -372,7 +374,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         album = Album(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [dpath])
         assert candidate is not None
-        assert not candidate.path.startswith(dpath)
+        assert dpath not in candidate.path.parents
 
     def test_main_interface_tries_amazon_before_aao(
         self, dpath, image_request_mock
@@ -424,11 +426,12 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         assert not image_request_mock.mocker.called
 
     def test_local_only_gets_fs_image(self, dpath, image_request_mock):
-        _common.touch(os.path.join(dpath, b"art.jpg"))
+        candidate_path = dpath / "art.jpg"
+        candidate_path.touch()
         album = Album(mb_albumid=self.MBID, asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [dpath], local_only=True)
         assert candidate is not None
-        assert candidate.path == os.path.join(dpath, b"art.jpg")
+        assert candidate.path == candidate_path
         assert not image_request_mock.mocker.called
 
 
@@ -976,7 +979,7 @@ class AlbumArtOperationMixin(UseThePlugin):
             yield
 
     def get_album_art(self):
-        return self.plugin.art_for_album(Album(), [""], True)
+        return self.plugin.art_for_album(Album(), [Path()], True)
 
 
 @REQUIRES_ARTRESIZER

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -278,6 +278,12 @@ class TestFSArt(UseThePlugin):
         candidate = next(source.get(Album(), settings, [dpath]))
         assert candidate.path == candidate_path
 
+    def test_uppercase_extension(self, source, dpath, settings) -> None:
+        candidate_path = dpath / "a.JPG"
+        candidate_path.touch()
+        candidate = next(source.get(Album(), settings, [dpath]))
+        assert candidate.path == candidate_path
+
     def test_appropriately_named_file_takes_precedence(
         self, source, dpath, settings
     ) -> None:

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -28,6 +28,8 @@ from beetsplug._utils import art
 if TYPE_CHECKING:
     from beets.test.helper import ImageRequestMocker
 
+_p = pytest.param
+
 
 def require_artresizer_compare(test):
     def wrapper(*args, **kwargs):
@@ -184,15 +186,30 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
             f"Image written is not {self.abbey_similarpath}"
         )
 
-    def test_non_ascii_album_path(self):
+    @pytest.mark.parametrize(
+        "filename, expect_error",
+        [
+            _p("extracted", False, id="success-filename"),
+            _p("/absolute/cover", True, id="error-absolute"),
+            _p("subdir/cover", True, id="error-subdir"),
+            _p(tempfile.gettempdir(), True, id="error-directory"),
+        ],
+    )
+    def test_filename_opt(self, caplog, filename, expect_error):
         resource_path = _common.RSRC / "image.mp3"
         album = self.add_album_fixture()
         trackpath = album.items()[0].filepath
         shutil.copy(resource_path, trackpath)
+        converted_path = album.filepath / "extracted.png"
 
-        self.run_command("extractart", "-a", "-n", "extracted")
+        with caplog.at_level("DEBUG"):
+            self.run_command("extractart", "-a", "-n", filename)
 
-        assert (album.filepath / "extracted.png").exists()
+        if expect_error:
+            assert "Only specify a name rather than a path" in caplog.text
+            assert not converted_path.exists()
+        else:
+            assert converted_path.exists()
 
     def test_extracted_extension(self):
         resource_path = _common.RSRC / "image-jpeg.mp3"

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -1,6 +1,5 @@
 """Tests for the 'permissions' plugin."""
 
-import os
 import platform
 from unittest.mock import Mock, patch
 
@@ -38,9 +37,12 @@ class TestPermissionsPlugin(AsIsImporterMixin, PluginMixin, ImportHelper):
         self.run_asis_importer()
         item = self.lib.items().get()
 
-        paths = (item.path, *dirs_in_library(self.lib.directory, item.path))
+        paths = (
+            item.filepath,
+            *dirs_in_library(self.lib.directory, item.filepath),
+        )
         for path in paths:
-            assert os.stat(path).st_mode & 0o777 == 511
+            assert path.stat().st_mode & 0o777 == 511
 
     def test_convert_perm_from_string(self):
         assert convert_perm("10") == 8
@@ -51,7 +53,7 @@ class TestPermissionsPlugin(AsIsImporterMixin, PluginMixin, ImportHelper):
     def test_permissions_on_set_art(self):
         self.do_set_art(True)
 
-    @patch("os.chmod", Mock())
+    @patch("pathlib.Path.chmod", Mock())
     def test_failing_permissions_on_set_art(self):
         self.do_set_art(False)
 
@@ -63,4 +65,4 @@ class TestPermissionsPlugin(AsIsImporterMixin, PluginMixin, ImportHelper):
         artpath = self.temp_path / "cover.jpg"
         artpath.touch()
         album.set_art(artpath)
-        assert expect_success == check_permissions(album.artpath, 0o777)
+        assert expect_success == check_permissions(album.art_filepath, 0o777)

--- a/test/plugins/test_play.py
+++ b/test/plugins/test_play.py
@@ -200,7 +200,7 @@ class PlayOnImportTest(
         with (
             patch(
                 "beetsplug.play.get_temp_filename",
-                side_effect=lambda *_, **__: playlist_path_bytes,
+                side_effect=lambda *_, **__: playlist_path,
             ),
             patch("beetsplug.play.subprocess.call") as subprocess_call_mock,
         ):

--- a/test/plugins/test_thumbnails.py
+++ b/test/plugins/test_thumbnails.py
@@ -1,10 +1,9 @@
-import os.path
+from pathlib import Path
 from unittest.mock import Mock, call, patch
 
 import pytest
 
 from beets.test.helper import BeetsTestCase
-from beets.util import syspath
 from beetsplug.thumbnails import (
     LARGE_DIR,
     NORMAL_DIR,
@@ -17,27 +16,25 @@ from beetsplug.thumbnails import (
 class ThumbnailsTest(BeetsTestCase):
     @patch("beetsplug.thumbnails.ArtResizer")
     @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok", Mock())
-    @patch("beetsplug.thumbnails.os.stat")
-    def test_add_tags(self, mock_stat, mock_artresizer):
+    @patch("pathlib.Path.stat")
+    def test_add_tags(self, path_stat, mock_artresizer):
+        artpath = Path("/path/to/cover")
         plugin = ThumbnailsPlugin()
-        plugin.get_uri = Mock(
-            side_effect={b"/path/to/cover": "COVER_URI"}.__getitem__
-        )
-        artpath = b"/path/to/cover"
-        mock_stat.return_value.st_mtime = 12345
+        plugin.get_uri = Mock(side_effect={artpath: "COVER_URI"}.__getitem__)
+        image_path = Path("/path/to/thumbnail")
+        path_stat.return_value.st_mtime = 12345
 
-        plugin.add_tags(artpath, b"/path/to/thumbnail")
+        plugin.add_tags(artpath, image_path)
 
         metadata = {"Thumb::URI": "COVER_URI", "Thumb::MTime": "12345"}
         mock_artresizer.shared.write_metadata.assert_called_once_with(
-            b"/path/to/thumbnail", metadata
+            image_path, metadata
         )
-        mock_stat.assert_called_once_with(syspath(artpath))
+        path_stat.assert_called_once()
 
-    @patch("beetsplug.thumbnails.os")
     @patch("beetsplug.thumbnails.ArtResizer")
     @patch("beetsplug.thumbnails.GioURI")
-    def test_check_local_ok(self, mock_giouri, mock_artresizer, mock_os):
+    def test_check_local_ok(self, mock_giouri, mock_artresizer):
         # test local resizing capability
         mock_artresizer.shared.local = False
         mock_artresizer.shared.can_write_metadata = False
@@ -48,25 +45,23 @@ class ThumbnailsTest(BeetsTestCase):
         mock_artresizer.shared.local = True
         mock_artresizer.shared.can_write_metadata = True
 
-        def exists(path):
-            if path == syspath(NORMAL_DIR):
+        def exists(self):
+            if self == NORMAL_DIR:
                 return False
-            if path == syspath(LARGE_DIR):
+            if self == LARGE_DIR:
                 return True
-            raise ValueError(f"unexpected path {path!r}")
+            raise ValueError(f"unexpected path {self!r}")
 
-        mock_os.path.exists = exists
         plugin = ThumbnailsPlugin()
-        mock_os.makedirs.assert_called_once_with(syspath(NORMAL_DIR))
+        assert NORMAL_DIR.exists()
+        assert LARGE_DIR.exists()
         assert plugin._check_local_ok()
 
-        # test metadata writer function
-        mock_os.path.exists = lambda _: True
-
-        mock_artresizer.shared.local = True
-        mock_artresizer.shared.can_write_metadata = False
-        with pytest.raises(RuntimeError):
-            ThumbnailsPlugin()
+        with patch("pathlib.Path.exists", autospec=True, side_effect=exists):
+            mock_artresizer.shared.local = True
+            mock_artresizer.shared.can_write_metadata = False
+            with pytest.raises(RuntimeError):
+                ThumbnailsPlugin()
 
         mock_artresizer.shared.local = True
         mock_artresizer.shared.can_write_metadata = True
@@ -83,51 +78,53 @@ class ThumbnailsTest(BeetsTestCase):
     @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok", Mock())
     @patch("beetsplug.thumbnails.ArtResizer")
     @patch("beets.util.syspath", Mock(side_effect=lambda x: x))
-    @patch("beetsplug.thumbnails.os")
     @patch("beetsplug.thumbnails.shutil")
-    def test_make_cover_thumbnail(self, mock_shutils, mock_os, mock_artresizer):
-        thumbnail_dir = os.path.normpath(b"/thumbnail/dir")
-        md5_file = os.path.join(thumbnail_dir, b"md5")
-        artpath = os.path.normpath(b"/path/to/art")
-        path_to_resized_art = os.path.normpath(b"/path/to/resized/artwork")
+    def test_make_cover_thumbnail(self, mock_shutils, mock_artresizer):
+        thumbnail_dir = Path("/thumbnail/dir")
+        md5_file = thumbnail_dir / "md5"
+        artpath = Path("/path/to/art")
+        path_to_resized_art = Path("/path/to/resized/artwork")
 
-        mock_os.path.join = os.path.join  # don't mock that function
         plugin = ThumbnailsPlugin()
         plugin.add_tags = Mock()
 
         album = Mock(artpath=artpath)
-        plugin.thumbnail_file_name = Mock(return_value=b"md5")
-        mock_os.path.exists.return_value = False
+        plugin.thumbnail_file_name = Mock(return_value="md5")
+        with patch(
+            "pathlib.Path.exists", autospec=True, return_value=False
+        ) as mock_exists:
+            mock_resize = mock_artresizer.shared.resize
+            mock_resize.return_value = path_to_resized_art
 
-        mock_resize = mock_artresizer.shared.resize
-        mock_resize.return_value = path_to_resized_art
+            plugin.make_cover_thumbnail(album, artpath, 12345, thumbnail_dir)
 
-        plugin.make_cover_thumbnail(album, artpath, 12345, thumbnail_dir)
+            mock_exists.assert_called_once_with(md5_file)
 
-        mock_os.path.exists.assert_called_once_with(syspath(md5_file))
-
-        mock_resize.assert_called_once_with(12345, artpath, md5_file)
-        plugin.add_tags.assert_called_once_with(artpath, path_to_resized_art)
-        mock_shutils.move.assert_called_once_with(
-            syspath(path_to_resized_art), syspath(md5_file)
-        )
+            mock_resize.assert_called_once_with(12345, artpath, md5_file)
+            plugin.add_tags.assert_called_once_with(
+                artpath, path_to_resized_art
+            )
+            mock_shutils.move.assert_called_once_with(
+                path_to_resized_art, md5_file
+            )
 
         # now test with recent thumbnail & with force
-        mock_os.path.exists.return_value = True
-        plugin.force = False
-        mock_resize.reset_mock()
-
-        def os_stat(target):
-            if target == syspath(md5_file):
+        def stat(self):
+            if self == md5_file:
                 return Mock(st_mtime=3)
-            if target == syspath(artpath):
+            if self == artpath:
                 return Mock(st_mtime=2)
-            raise ValueError(f"invalid target {target}")
+            raise ValueError(f"invalid target {self}")
 
-        mock_os.stat.side_effect = os_stat
+        with (
+            patch("pathlib.Path.exists", autospec=True, return_value=True),
+            patch("pathlib.Path.stat", autospec=True, side_effect=stat),
+        ):
+            plugin.force = False
+            mock_resize.reset_mock()
 
-        plugin.make_cover_thumbnail(album, artpath, 12345, thumbnail_dir)
-        assert mock_resize.call_count == 0
+            plugin.make_cover_thumbnail(album, artpath, 12345, thumbnail_dir)
+            assert mock_resize.call_count == 0
 
         # and with force
         plugin.config["force"] = True
@@ -138,16 +135,14 @@ class ThumbnailsTest(BeetsTestCase):
     def test_make_dolphin_cover_thumbnail(self):
         plugin = ThumbnailsPlugin()
         tmp = self.temp_path
-        album = Mock(
-            path=os.fsencode(tmp), artpath=os.fsencode(tmp / "cover.jpg")
-        )
-        plugin.make_dolphin_cover_thumbnail(album.path, album.artpath)
+        album = Mock(filepath=tmp, art_filepath=tmp / "cover.jpg")
+        plugin.make_dolphin_cover_thumbnail(album.filepath, album.art_filepath)
         filename = tmp / ".directory"
         assert filename.read_text() == "[Desktop Entry]\nIcon=./cover.jpg"
 
         # not rewritten when it already exists (yup that's a big limitation)
         album.artpath = b"/my/awesome/art.tiff"
-        plugin.make_dolphin_cover_thumbnail(album.path, album.artpath)
+        plugin.make_dolphin_cover_thumbnail(album.filepath, album.art_filepath)
         assert filename.read_text() == "[Desktop Entry]\nIcon=./cover.jpg"
 
     @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok", Mock())
@@ -160,16 +155,16 @@ class ThumbnailsTest(BeetsTestCase):
         make_dolphin = plugin.make_dolphin_cover_thumbnail = Mock()
 
         # no art
-        album = Mock(artpath=None)
+        album = Mock(art_filepath=None)
         plugin.process_album(album)
         assert get_size.call_count == 0
         assert make_dolphin.call_count == 0
 
         # cannot get art size
-        album.artpath = b"/path/to/art"
+        album.art_filepath = b"/path/to/art"
         get_size.return_value = None
         plugin.process_album(album)
-        get_size.assert_called_once_with(b"/path/to/art")
+        get_size.assert_called_once_with(album.art_filepath)
         assert make_cover.call_count == 0
 
         # dolphin tests
@@ -179,13 +174,13 @@ class ThumbnailsTest(BeetsTestCase):
 
         plugin.config["dolphin"] = True
         plugin.process_album(album)
-        make_dolphin.assert_called_once_with(album.path, album.artpath)
+        make_dolphin.assert_called_once_with(album.filepath, album.art_filepath)
 
         # small art
         get_size.return_value = 200, 200
         plugin.process_album(album)
         make_cover.assert_called_once_with(
-            album, album.artpath, 128, NORMAL_DIR
+            album, album.art_filepath, 128, NORMAL_DIR
         )
 
         # big art
@@ -194,8 +189,8 @@ class ThumbnailsTest(BeetsTestCase):
         plugin.process_album(album)
         make_cover.assert_has_calls(
             [
-                call(album, album.artpath, 128, NORMAL_DIR),
-                call(album, album.artpath, 256, LARGE_DIR),
+                call(album, album.art_filepath, 128, NORMAL_DIR),
+                call(album, album.art_filepath, 256, LARGE_DIR),
             ],
             any_order=True,
         )
@@ -215,13 +210,12 @@ class ThumbnailsTest(BeetsTestCase):
             [call(album), call(album2)], any_order=True
         )
 
-    @patch("beetsplug.thumbnails.BaseDirectory")
-    def test_thumbnail_file_name(self, mock_basedir):
+    def test_thumbnail_file_name(self):
         plug = ThumbnailsPlugin()
         plug.get_uri = Mock(return_value="file:///my/uri")
         assert (
-            plug.thumbnail_file_name(b"idontcare")
-            == b"9488f5797fbe12ffb316d607dfd93d04.png"
+            plug.thumbnail_file_name(Path("idontcare"))
+            == "9488f5797fbe12ffb316d607dfd93d04.png"
         )
 
     def test_uri(self):
@@ -229,16 +223,9 @@ class ThumbnailsTest(BeetsTestCase):
         if not gio.available:
             self.skipTest("GIO library not found")
 
-        import ctypes
-
-        with pytest.raises(ctypes.ArgumentError):
-            gio.uri("/foo")
-        assert gio.uri(b"/foo") == "file:///foo"
-        assert gio.uri(b"/foo!") == "file:///foo!"
-        assert (
-            gio.uri(b"/music/\xec\x8b\xb8\xec\x9d\xb4")
-            == "file:///music/%EC%8B%B8%EC%9D%B4"
-        )
+        assert gio.uri("/foo") == "file:///foo"
+        assert gio.uri("/foo!") == "file:///foo!"
+        assert gio.uri("/music/싸이") == "file:///music/%EC%8B%B8%EC%9D%B4"
 
 
 class TestPathlibURI:
@@ -247,5 +234,5 @@ class TestPathlibURI:
     def test_uri(self):
         test_uri = PathlibURI()
 
-        # test it won't break if we pass it bytes for a path
-        test_uri.uri(b"/")
+        # test it won't break if we pass it str for a path
+        test_uri.uri("/")

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -88,7 +88,7 @@ class MoveTest(BeetsTestCase):
 
     def test_move_changes_path(self):
         self.i.move()
-        assert self.i.path == util.normpath(self.dest)
+        assert self.i.path == util.normpath(os.fsencode(self.dest))
 
     def test_copy_already_at_destination(self):
         self.i.move()
@@ -158,7 +158,7 @@ class MoveTest(BeetsTestCase):
     @unittest.skipUnless(_common.HAVE_SYMLINK, "need symlinks")
     def test_link_changes_path(self):
         self.i.move(operation=MoveOperation.LINK)
-        assert self.i.path == util.normpath(self.dest)
+        assert self.i.path == util.normpath(os.fsencode(self.dest))
 
     @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
     def test_hardlink_arrives(self):
@@ -179,7 +179,7 @@ class MoveTest(BeetsTestCase):
     @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
     def test_hardlink_changes_path(self):
         self.i.move(operation=MoveOperation.HARDLINK)
-        assert self.i.path == util.normpath(self.dest)
+        assert self.i.path == util.normpath(os.fsencode(self.dest))
 
     @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
     def test_hardlink_from_symlink(self):

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -185,17 +185,17 @@ class TestDestination(PytestItemHelper):
         return super().create_temp_dir(**kwargs)
 
     def test_directory_works_with_trailing_slash(self, item_in_db):
-        self.lib.directory = b"one/"
+        self.lib.directory = Path("one/")
         self.lib.path_formats = [("default", "two")]
         assert item_in_db.destination() == np("one/two")
 
     def test_directory_works_without_trailing_slash(self, item_in_db):
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [("default", "two")]
         assert item_in_db.destination() == np("one/two")
 
     def test_destination_substitutes_metadata_values(self, item_in_db):
-        self.lib.directory = b"base"
+        self.lib.directory = Path("base")
         self.lib.path_formats = [("default", "$album/$artist $title")]
         item_in_db.title = "three"
         item_in_db.artist = "two"
@@ -203,19 +203,19 @@ class TestDestination(PytestItemHelper):
         assert item_in_db.destination() == np("base/one/two three")
 
     def test_destination_preserves_extension(self, item_in_db):
-        self.lib.directory = b"base"
+        self.lib.directory = Path("base")
         self.lib.path_formats = [("default", "$title")]
         item_in_db.path = "hey.audioformat"
         assert item_in_db.destination() == np("base/the title.audioformat")
 
     def test_lower_case_extension(self, item_in_db):
-        self.lib.directory = b"base"
+        self.lib.directory = Path("base")
         self.lib.path_formats = [("default", "$title")]
         item_in_db.path = "hey.MP3"
         assert item_in_db.destination() == np("base/the title.mp3")
 
     def test_destination_pads_some_indices(self, item_in_db):
-        self.lib.directory = b"base"
+        self.lib.directory = Path("base")
         self.lib.path_formats = [
             ("default", "$track $tracktotal $disc $disctotal $bpm")
         ]
@@ -227,7 +227,7 @@ class TestDestination(PytestItemHelper):
         assert item_in_db.destination() == np("base/01 02 03 04 5")
 
     def test_destination_pads_date_values(self, item_in_db):
-        self.lib.directory = b"base"
+        self.lib.directory = Path("base")
         self.lib.path_formats = [("default", "$year-$month-$day")]
         item_in_db.year = 1
         item_in_db.month = 2
@@ -293,12 +293,12 @@ class TestDestination(PytestItemHelper):
     def test_default_path_for_non_compilations(self, item_in_db):
         item_in_db.comp = False
         self.lib.add_album([item_in_db])
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [("default", "two"), ("comp:true", "three")]
         assert item_in_db.destination() == np("one/two")
 
     def test_singleton_path(self, item_in_db):
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [
             ("default", "two"),
             ("singleton:true", "four"),
@@ -308,7 +308,7 @@ class TestDestination(PytestItemHelper):
 
     def test_comp_before_singleton_path(self, item_in_db):
         item_in_db.comp = True
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [
             ("default", "two"),
             ("comp:true", "three"),
@@ -319,13 +319,13 @@ class TestDestination(PytestItemHelper):
     def test_comp_path(self, item_in_db):
         item_in_db.comp = True
         self.lib.add_album([item_in_db])
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [("default", "two"), ("comp:true", "three")]
         assert item_in_db.destination() == np("one/three")
 
     def test_multi_value_string_query_path(self, item_in_db):
         item_in_db.genres = ["Classical"]
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [
             ("default", "two"),
             ("genres:=~Classical", "three"),
@@ -334,7 +334,7 @@ class TestDestination(PytestItemHelper):
 
     def test_multi_value_match_query_path(self, item_in_db):
         item_in_db.genres = ["Classical"]
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [
             ("default", "two"),
             ("genres:=Classical", "three"),
@@ -343,7 +343,7 @@ class TestDestination(PytestItemHelper):
 
     def test_multi_value_string_query_path_no_substring_match(self, item_in_db):
         item_in_db.genres = ["Neoclassical"]
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [
             ("default", "two"),
             ("genres:=~Classical", "three"),
@@ -354,7 +354,7 @@ class TestDestination(PytestItemHelper):
         item_in_db.comp = True
         self.lib.add_album([item_in_db])
         item_in_db.albumtype = "sometype"
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [
             ("default", "two"),
             ("albumtype:sometype", "four"),
@@ -366,7 +366,7 @@ class TestDestination(PytestItemHelper):
         item_in_db.comp = True
         self.lib.add_album([item_in_db])
         item_in_db.albumtype = "sometype"
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [
             ("default", "two"),
             ("albumtype:anothertype", "four"),
@@ -448,13 +448,13 @@ class TestDestination(PytestItemHelper):
 
     def test_asciify_character_expanding_to_slash(self, item_in_db):
         config["asciify_paths"] = True
-        self.lib.directory = b"lib"
+        self.lib.directory = Path("lib")
         self.lib.path_formats = [("default", "$title")]
         item_in_db.title = "ab\xa2\xbdd"
         assert item_in_db.destination() == np("lib/abC_ 1_2d")
 
     def test_destination_with_replacements(self, item_in_db):
-        self.lib.directory = b"base"
+        self.lib.directory = Path("base")
         self.lib.replacements = [(re.compile(r"a"), "e")]
         self.lib.path_formats = [("default", "$album/$title")]
         item_in_db.title = "foo"
@@ -463,7 +463,7 @@ class TestDestination(PytestItemHelper):
 
     @unittest.skip("unimplemented: #359")
     def test_destination_with_empty_component(self, item_in_db):
-        self.lib.directory = b"base"
+        self.lib.directory = Path("base")
         self.lib.replacements = [(re.compile(r"^$"), "_")]
         self.lib.path_formats = [("default", "$album/$artist/$title")]
         item_in_db.title = "three"
@@ -474,7 +474,7 @@ class TestDestination(PytestItemHelper):
 
     @unittest.skip("unimplemented: #359")
     def test_destination_with_empty_final_component(self, item_in_db):
-        self.lib.directory = b"base"
+        self.lib.directory = Path("base")
         self.lib.replacements = [(re.compile(r"^$"), "_")]
         self.lib.path_formats = [("default", "$album/$title")]
         item_in_db.title = ""
@@ -483,7 +483,7 @@ class TestDestination(PytestItemHelper):
         assert item_in_db.destination() == np("base/one/_.mp3")
 
     def test_album_field_query(self, item_in_db):
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [("default", "two"), ("flex:foo", "three")]
         album = self.lib.add_album([item_in_db])
         assert item_in_db.destination() == np("one/two")
@@ -492,7 +492,7 @@ class TestDestination(PytestItemHelper):
         assert item_in_db.destination() == np("one/three")
 
     def test_album_field_in_template(self, item_in_db):
-        self.lib.directory = b"one"
+        self.lib.directory = Path("one")
         self.lib.path_formats = [("default", "$flex/two")]
         album = self.lib.add_album([item_in_db])
         album["flex"] = "foo"
@@ -583,7 +583,7 @@ class PathFormattingMixin:
 class TestDestinationFunction(TestHelper, PathFormattingMixin):
     @pytest.fixture(autouse=True)
     def item(self, setup):
-        self.lib.directory = b"/base"
+        self.lib.directory = Path("/base")
         self.lib.path_formats = [("default", "path")]
         return item(self.lib)
 
@@ -691,7 +691,7 @@ class TestDestinationFunction(TestHelper, PathFormattingMixin):
 class TestDisambiguation(TestHelper, PathFormattingMixin):
     @pytest.fixture(autouse=True)
     def items(self, setup):
-        self.lib.directory = b"/base"
+        self.lib.directory = Path("/base")
         self.lib.path_formats = [("default", "path")]
 
         i1 = item()
@@ -786,7 +786,7 @@ class TestDisambiguation(TestHelper, PathFormattingMixin):
 class TestSingletonDisambiguation(TestHelper, PathFormattingMixin):
     @pytest.fixture(autouse=True)
     def items(self, setup):
-        self.lib.directory = b"/base"
+        self.lib.directory = Path("/base")
         self.lib.path_formats = [("default", "path")]
 
         i1 = item()
@@ -890,7 +890,7 @@ class TestPluginDestination(TestHelper):
         self.old_field_getters = plugins.item_field_getters
         plugins.item_field_getters = field_getters
 
-        self.lib.directory = b"/base"
+        self.lib.directory = Path("/base")
         self.lib.path_formats = [("default", "$artist $foo")]
 
         yield _common.item(self.lib)
@@ -899,7 +899,7 @@ class TestPluginDestination(TestHelper):
 
     def _assert_dest(self, dest, item):
         with _common.platform_posix():
-            the_dest = item.destination()
+            the_dest = item.destination(basedir=b"/base")
         assert the_dest == b"/base/" + dest
 
     def test_undefined_value_not_substituted(self, item):

--- a/test/util/test_art_resize.py
+++ b/test/util/test_art_resize.py
@@ -1,8 +1,6 @@
 """Tests for image resizing based on filesize."""
 
-import os
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 from beets.test import _common
@@ -26,34 +24,30 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
             225, self.IMG_225x225, quality=95, max_filesize=0
         )
         # check valid path returned - max_filesize hasn't broken resize command
-        assert Path(os.fsdecode(im_95_qual)).exists()
+        assert im_95_qual.exists()
 
         # Attempt a lower filesize with same quality
+        im_95_size = im_95_qual.stat().st_size
         im_a = backend.resize(
-            225,
-            self.IMG_225x225,
-            quality=95,
-            max_filesize=0.9 * os.stat(im_95_qual).st_size,
+            225, self.IMG_225x225, quality=95, max_filesize=0.9 * im_95_size
         )
-        assert Path(os.fsdecode(im_a)).exists()
+        assert im_a.exists()
         # target size was achieved
-        assert os.stat(im_a).st_size < os.stat(im_95_qual).st_size
+        assert im_a.stat().st_size < im_95_size
 
         # Attempt with lower initial quality
         im_75_qual = backend.resize(
             225, self.IMG_225x225, quality=75, max_filesize=0
         )
-        assert Path(os.fsdecode(im_75_qual)).exists()
+        assert im_75_qual.exists()
 
+        im_75_size = im_75_qual.stat().st_size
         im_b = backend.resize(
-            225,
-            self.IMG_225x225,
-            quality=95,
-            max_filesize=0.9 * os.stat(im_75_qual).st_size,
+            225, self.IMG_225x225, quality=95, max_filesize=0.9 * im_75_size
         )
-        assert Path(os.fsdecode(im_b)).exists()
+        assert im_b.exists()
         # Check high (initial) quality still gives a smaller filesize
-        assert os.stat(im_b).st_size < os.stat(im_75_qual).st_size
+        assert im_b.stat().st_size < im_75_size
 
     @unittest.skipUnless(PILBackend.available(), "PIL not available")
     def test_pil_file_resize(self):
@@ -87,7 +81,7 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
         """
         im = IMBackend()
         path = im.deinterlace(self.IMG_225x225)
-        cmd = [*im.identify_cmd, "-format", "%[interlace]", os.fsdecode(path)]
+        cmd = [*im.identify_cmd, "-format", "%[interlace]", str(path)]
         out = command_output(cmd).stdout
         assert out == b"None"
 

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'fetchart'" },
     { name = "beautifulsoup4", marker = "extra == 'lyrics'" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "confuse", specifier = ">=2.2.0" },
+    { name = "confuse", specifier = ">=2.2.1" },
     { name = "dbus-python", marker = "sys_platform != 'win32' and extra == 'metasync'" },
     { name = "flask", marker = "extra == 'aura'" },
     { name = "flask", marker = "extra == 'web'" },


### PR DESCRIPTION
Fixes #6967

#### What changed

- `Library.directory` now uses `pathlib.Path` instead of string/bytes-style directory values.
- Path ownership is pushed into `Library`, with small helper APIs like `contains_path()` and `is_in_directory()` replacing repeated ancestry checks across the codebase.
- Callers that still need byte paths for older file-moving logic now convert explicitly at the boundary with `os.fsencode(...)`.

#### Architecture impact

- This centralizes library path logic in `beets.library.library.Library` instead of spreading low-level path checks across importers, UI commands, models, and plugins.
- The change moves the codebase toward a clearer split:
  - high-level code works with `Path` objects
  - compatibility code converts only where older path APIs still require bytes
- Several plugins and commands now use path-native operations like `Path.is_dir()`, `Path.chmod()`, `Path.stat()`, and `Path` joins, which reduces manual path handling.

#### Why this matters

- Makes path handling more consistent and easier to reason about.
- Reduces duplicated "is this file inside the library?" logic.
- Creates a cleaner base for future migration away from mixed string/bytes filesystem handling.

#### High-level impact for reviewers

- Most call-site changes are mechanical updates from raw path checks to `Library` helpers or `Path` methods.
- The main behavior change is type normalization around `Library.directory`; file placement and cleanup logic should remain the same.
- Good review focus areas are duplicate cleanup, move/sync flows, and plugins that manipulate filesystem paths or permissions.
