### PR TITLE
importadded: preserve_write_mtimes targets the written file, not the source

### DIFF
--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -163,12 +163,16 @@ class ImportAddedPlugin(BeetsPlugin):
             item.store()
 
     def update_after_write_time(self, item: Item, path: bytes) -> None:
-        """Update the mtime of the item's file with the item.added value
+        """Update the mtime of the written file with the item.added value
         after each write of the item if `preserve_write_mtimes` is enabled.
         """
         if item.added:
             if self.config["preserve_write_mtimes"].get(bool):
-                self.write_item_mtime(item, item.added)
+                self.write_file_mtime(util.syspath(path), item.added)
+                if path == item.path:
+                    # The file's mtime on disk must be in sync with the
+                    # item's mtime
+                    item.mtime = int(item.added)
             self._log.debug(
                 "Write of item '{0.filepath}', selected item.added={0.added}",
                 item,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,10 @@ Bug fixes
   digits no longer restarts the numbering: ``track.10.mp3`` now yields
   ``track.11.mp3`` instead of ``track.1.mp3``. The counter was matched with
   ``\.(\d)+$``, which captures only the final digit.
+- :doc:`/plugins/importadded`: The ``preserve_write_mtimes`` option no
+  longer writes to the item's source file when ``beet convert`` writes the
+  converted file, which previously crashed with a :class:`PermissionError`
+  when the source file was read-only. :bug:`6954`
 - Autotagging distance calculations no longer treat ordinary words containing
   "ft" (such as "draft", "left", "gift", "craft") as a "featuring artist"
   suffix, which was silently making genuinely different titles/artists score as

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,10 +37,10 @@ Bug fixes
   digits no longer restarts the numbering: ``track.10.mp3`` now yields
   ``track.11.mp3`` instead of ``track.1.mp3``. The counter was matched with
   ``\.(\d)+$``, which captures only the final digit.
-- :doc:`/plugins/importadded`: The ``preserve_write_mtimes`` option no
-  longer writes to the item's source file when ``beet convert`` writes the
-  converted file, which previously crashed with a :class:`PermissionError`
-  when the source file was read-only. :bug:`6954`
+- :doc:`/plugins/importadded`: The ``preserve_write_mtimes`` option no longer
+  writes to the item's source file when ``beet convert`` writes the converted
+  file, which previously crashed with a :class:`PermissionError` when the source
+  file was read-only. :bug:`6954`
 - Autotagging distance calculations no longer treat ordinary words containing
   "ft" (such as "draft", "left", "gift", "craft") as a "featuring artist"
   suffix, which was silently making genuinely different titles/artists score as

--- a/test/plugins/test_importadded_convert.py
+++ b/test/plugins/test_importadded_convert.py
@@ -1,0 +1,73 @@
+"""Tests for the `importadded` plugin in `beet convert` scenarios."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from beets import plugins as beets_plugins
+from beets import util
+
+from .test_convert import ConvertCommand, ConvertPluginHelper
+
+if TYPE_CHECKING:
+    from beets.library import Item
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="win32")
+class TestConvertImportAdded(ConvertPluginHelper, ConvertCommand):
+    """The convert command must not need to write to the source file.
+
+    With `preserve_write_mtimes`, `importadded` re-applies `item.added`
+    to the file beets just wrote. `beet convert` writes the *converted*
+    file, so the plugin must leave the (possibly read-only) source file
+    alone.
+    """
+
+    preload_plugin = False
+
+    def setup_beets(self):
+        super().setup_beets()
+        self.config["plugins"] = ["convert", "importadded"]
+        beets_plugins.load_plugins()
+        self.config["importadded"] = {
+            "preserve_mtimes": True,
+            "preserve_write_mtimes": True,
+        }
+        self.item = self.add_item_fixture(ext="flac")
+        self.item.added = time.time() - 60000
+        self.item.store()
+        self.converted = self.convert_dest / "converted.mp3"
+        self.config["convert"] = {
+            "paths": {"default": "converted"},
+            "format": "mp3",
+            "formats": {"mp3": self.tagged_copy_cmd("mp3")},
+        }
+
+    def source_mtime(self, item: Item) -> float:
+        return item.filepath.stat().st_mtime
+
+    def test_convert_does_not_touch_source_mtime(self):
+        mtime_before = self.source_mtime(self.item)
+        self.run_convert("--yes")
+        assert self.converted.exists()
+        assert self.source_mtime(self.item) == mtime_before
+
+    def test_convert_with_readonly_source(self, monkeypatch):
+        # Simulate a read-only (e.g. immutable) source file: os.utime on the
+        # item's own path must not be attempted at all.
+        source = util.syspath(self.item.path)
+        real_utime = os.utime
+
+        def denied(path, *args, **kwargs):
+            if str(path) == str(source):
+                raise PermissionError(1, "Operation not permitted", str(path))
+            return real_utime(path, *args, **kwargs)
+
+        monkeypatch.setattr("beetsplug.importadded.os.utime", denied)
+        self.run_convert("--yes")
+        assert self.converted.exists()


### PR DESCRIPTION
# importadded: preserve_write_mtimes targets the written file, not the source

## What this fixes

With `importadded` and `preserve_write_mtimes` enabled, `beet convert`
crashes when the source file is read-only (in my case, files with the
immutable bit set):

```
PermissionError: [Errno 1] Operation not permitted: '.../01 somename.flac'
```

The conversion itself never needs to write the source file — but the
plugin does.

## Why it happens

`update_after_write_time(item, path)` is invoked from the `after_write`
event that `Item.write()` sends at the end of every write
(`beets/library/models.py`), where `path` is the file that was just
written. Under `beet convert` that is the converted file
(`item.try_write(path=converted)`), not the source. The plugin currently
ignores `path` and unconditionally calls `write_item_mtime(item, ...)`,
which does `os.utime` on `item.path` — the source file — and stomps
`item.mtime` even though the source was not the file being written.

## The fix

Point the mtime write at `path` (the file actually written), and only
sync `item.mtime` when `path` is the item's own file:

```python
self.write_file_mtime(util.syspath(path), item.added)
if path == item.path:
    item.mtime = int(item.added)
```

This mirrors what `Item.write()` itself does
(`if path == self.path: self.mtime = self.current_mtime()`), so the DB
field stays consistent with the same rule the library already applies.
Ordinary writes (`beet write`, tagging after import) pass
`path == item.path`, so their behavior is unchanged — all existing
`importadded` tests pass as-is.

## Tests

New `test/plugins/test_importadded_convert.py` (2 tests, convert +
importadded with both preserve options on):

- `test_convert_does_not_touch_source_mtime`: the source file's mtime is
  left alone and the converted file carries the `added` mtime.
- `test_convert_with_readonly_source`: a source whose `os.utime` raises
  `PermissionError` no longer crashes the convert.

Red without the fix (2 failed: mtime assert + the PermissionError from
the issue), green with it. `pytest -k "importadded or convert"`: 48
passed, 6 skipped (optional dependencies). `ruff check` and
`ruff format --check` clean.

Fixes #6954
