### PR TITLE
pathlib migration: migrate importer to use `pathlib.Path`

### DIFF
--- a/beets/events.py
+++ b/beets/events.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict, get_args
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from pathlib import Path
 
     from beets.autotag import AlbumInfo, TrackInfo
     from beets.autotag.match import AlbumMatch
@@ -90,7 +91,7 @@ class ImportTaskEventArgs(TypedDict):
 
 class ImportEventArgs(TypedDict):
     lib: Library
-    paths: list[bytes]
+    paths: list[Path]
 
 
 class AlbumImportedEventArgs(TypedDict):

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import os
 import time
 from typing import TYPE_CHECKING
 
-from beets import config, logging, plugins, util
-from beets.util import displayable_path, normpath, pipeline, syspath
+from beets import config, logging, plugins
+from beets.util import displayable_path, normpath, pipeline
 
 from . import stages as stagefuncs
 from .actions import Action, DuplicateAction
@@ -13,13 +12,13 @@ from .state import ImportState
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
+    from pathlib import Path
 
     import confuse
 
     from beets import dbcore, library
     from beets.autotag import AlbumMatch, TrackMatch
     from beets.library import AlbumOrItem
-    from beets.util import PathBytes
 
     from .tasks import ImportTask, SingletonImportTask
 
@@ -40,18 +39,18 @@ class ImportSession:
     """
 
     logger: logging.Logger
-    paths: list[PathBytes]
+    paths: list[Path]
     lib: library.Library
 
-    _is_resuming: dict[bytes, bool]
-    _merged_items: set[PathBytes]
-    _merged_dirs: set[PathBytes]
+    _is_resuming: dict[Path, bool]
+    _merged_items: set[Path]
+    _merged_dirs: set[Path]
 
     def __init__(
         self,
         lib: library.Library,
         loghandler: logging.Handler | None,
-        paths: Sequence[PathBytes] | None,
+        paths: Sequence[Path] | None,
         query: str | Sequence[str] | dbcore.Query | None = None,
     ) -> None:
         """Create a session.
@@ -139,7 +138,7 @@ class ImportSession:
 
         self.want_resume = config["resume"].as_choice([True, False, "ask"])
 
-    def tag_log(self, status: str, paths: Sequence[PathBytes]) -> None:
+    def tag_log(self, status: str, paths: Sequence[Path]) -> None:
         """Log a message about a given album to the importer log. The status
         should reflect the reason the album couldn't be tagged.
         """
@@ -166,7 +165,7 @@ class ImportSession:
             elif task.skip:
                 self.tag_log("skip", paths)
 
-    def should_resume(self, path: PathBytes) -> bool:
+    def should_resume(self, path: Path) -> bool:
         raise NotImplementedError
 
     def choose_match(self, task: ImportTask) -> AlbumMatch | Action:
@@ -243,9 +242,7 @@ class ImportSession:
 
     # Incremental and resumed imports
 
-    def already_imported(
-        self, toppath: PathBytes, paths: Sequence[PathBytes]
-    ) -> bool:
+    def already_imported(self, toppath: Path, paths: Sequence[Path]) -> bool:
         """Returns true if the files belonging to this task have already
         been imported in a previous session.
         """
@@ -261,13 +258,13 @@ class ImportSession:
     _history_dirs = None
 
     @property
-    def history_dirs(self) -> set[tuple[PathBytes, ...]]:
+    def history_dirs(self) -> set[tuple[Path, ...]]:
         # FIXME: This could be simplified to a cached property
         if self._history_dirs is None:
             self._history_dirs = ImportState().taghistory
         return self._history_dirs
 
-    def already_merged(self, paths: Sequence[PathBytes]) -> bool:
+    def already_merged(self, paths: Sequence[Path]) -> bool:
         """Returns true if all the paths being imported were part of a merge
         during previous tasks.
         """
@@ -276,23 +273,20 @@ class ImportSession:
                 return False
         return True
 
-    def mark_merged(self, paths: Sequence[PathBytes]) -> None:
+    def mark_merged(self, paths: Sequence[Path]) -> None:
         """Mark paths and directories as merged for future reimport tasks."""
         self._merged_items.update(paths)
-        dirs = {
-            os.path.dirname(path) if os.path.isfile(syspath(path)) else path
-            for path in paths
-        }
+        dirs = {p.parent if p.is_file() else p for p in paths}
         self._merged_dirs.update(dirs)
 
-    def is_resuming(self, toppath: PathBytes) -> bool:
+    def is_resuming(self, toppath: Path) -> bool:
         """Return `True` if user wants to resume import of this path.
 
         You have to call `ask_resume` first to determine the return value.
         """
         return self._is_resuming.get(toppath, False)
 
-    def ask_resume(self, toppath: PathBytes) -> None:
+    def ask_resume(self, toppath: Path) -> None:
         """If import of `toppath` was aborted in an earlier session, ask
         user if they want to resume the import.
 
@@ -301,10 +295,7 @@ class ImportSession:
         if self.want_resume and ImportState().progress_has(toppath):
             # Either accept immediately or prompt for input to decide.
             if self.want_resume is True or self.should_resume(toppath):
-                log.warning(
-                    "Resuming interrupted import of {}",
-                    util.displayable_path(toppath),
-                )
+                log.warning("Resuming interrupted import of {}", toppath)
                 self._is_resuming[toppath] = True
             else:
                 # Clear progress; we're starting from the top.

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import contextvars
 import itertools
 import logging
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 
 from beets import config, plugins
@@ -53,7 +55,7 @@ def read_tasks(session: ImportSession) -> Iterator[BaseImportTask]:
         skipped += task_factory.skipped
 
         if not task_factory.imported:
-            log.warning("No files imported from {}", displayable_path(toppath))
+            log.warning("No files imported from {}", toppath)
 
     # Show skipped directories (due to incremental/resume).
     if skipped:
@@ -82,7 +84,9 @@ def query_tasks(session: ImportSession) -> Iterator[BaseImportTask]:
             items = list(album.items())
             _freshen_items(items)
 
-            task = ImportTask(None, [album.item_dir()], items)
+            task = ImportTask(
+                None, [Path(os.fsdecode(album.item_dir()))], items
+            )
             for task in task.handle_created(session):
                 yield task
 
@@ -113,7 +117,9 @@ def group_albums(session: ImportSession) -> StageCoro:
         sorted_items: list[library.Item] = sorted(task.items, key=group)
         for _, items in itertools.groupby(sorted_items, group):
             l_items = list(items)
-            task = ImportTask(task.toppath, [i.path for i in l_items], l_items)
+            task = ImportTask(
+                task.toppath, [i.filepath for i in l_items], l_items
+            )
             tasks += task.handle_created(session)
         tasks.append(SentinelImportTask(task.toppath, task.paths))
 
@@ -195,7 +201,7 @@ def user_query(session: ImportSession, task: ImportTask) -> StageReturn:
 
         # Duplicates would be reimported so make them look "fresh"
         _freshen_items(duplicate_items)
-        duplicate_paths = [item.path for item in duplicate_items]
+        duplicate_paths = [item.filepath for item in duplicate_items]
 
         # Record merged paths in the session so they are not reimported
         session.mark_merged(duplicate_paths)
@@ -253,11 +259,11 @@ def plugin_stage(
 def log_files(session: ImportSession, task: ImportTask) -> None:
     """A coroutine (pipeline stage) to log each file to be imported."""
     if isinstance(task, SingletonImportTask):
-        log.info("Singleton: {}", displayable_path(task.item["path"]))
+        log.info("Singleton: {}", task.item.filepath)
     elif task.items:
-        log.info("Album: {}", displayable_path(task.paths[0]))
+        log.info("Album: {}", task.paths[0])
         for item in task.items:
-            log.info("  {}", displayable_path(item["path"]))
+            log.info("  {}", item.filepath)
 
 
 # --------------------------------- Consumer --------------------------------- #

--- a/beets/importer/state.py
+++ b/beets/importer/state.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import pickle
 from bisect import bisect_left, insort
 from dataclasses import dataclass
@@ -14,7 +13,7 @@ from beets import config
 if TYPE_CHECKING:
     from types import TracebackType
 
-    from beets.util import PathBytes
+    from beets.util import Path
 
 
 # Global logger.
@@ -47,14 +46,14 @@ class ImportState:
     ```
     """
 
-    tagprogress: dict[PathBytes, list[PathBytes]]
-    taghistory: set[tuple[PathBytes, ...]]
-    path: PathBytes
+    tagprogress: dict[Path, list[Path]]
+    taghistory: set[tuple[Path, ...]]
+    path: Path
 
     def __init__(
-        self, readonly: bool = False, path: PathBytes | None = None
+        self, readonly: bool = False, path: Path | None = None
     ) -> None:
-        self.path = path or os.fsencode(config["statefile"].as_filename())
+        self.path = path or config["statefile"].as_path()
         self.tagprogress = {}
         self.taghistory = set()
         self._open()
@@ -72,7 +71,7 @@ class ImportState:
 
     def _open(self) -> None:
         try:
-            with open(self.path, "rb") as f:
+            with self.path.open("rb") as f:
                 state = pickle.load(f)
                 # Read the states
                 self.tagprogress = state.get("tagprogress", {})
@@ -86,7 +85,7 @@ class ImportState:
 
     def _save(self) -> None:
         try:
-            with open(self.path, "wb") as f:
+            with self.path.open("wb") as f:
                 pickle.dump(
                     {
                         "tagprogress": self.tagprogress,
@@ -99,7 +98,7 @@ class ImportState:
 
     # -------------------------------- Tagprogress ------------------------------- #
 
-    def progress_add(self, toppath: PathBytes, *paths: PathBytes) -> None:
+    def progress_add(self, toppath: Path, *paths: Path) -> None:
         """Record that the files under all of the `paths` have been imported
         under `toppath`.
         """
@@ -111,19 +110,19 @@ class ImportState:
                 else:
                     insort(imported, path)
 
-    def progress_has_element(self, toppath: PathBytes, path: PathBytes) -> bool:
+    def progress_has_element(self, toppath: Path, path: Path) -> bool:
         """Return whether `path` has been imported in `toppath`."""
         imported = self.tagprogress.get(toppath, [])
         i = bisect_left(imported, path)
         return i != len(imported) and imported[i] == path
 
-    def progress_has(self, toppath: PathBytes) -> bool:
+    def progress_has(self, toppath: Path) -> bool:
         """Return `True` if there exist paths that have already been
         imported under `toppath`.
         """
         return toppath in self.tagprogress
 
-    def progress_reset(self, toppath: PathBytes | None) -> None:
+    def progress_reset(self, toppath: Path | None) -> None:
         """Reset the progress for `toppath`."""
         with self as state:
             if toppath in state.tagprogress:
@@ -131,7 +130,7 @@ class ImportState:
 
     # -------------------------------- Taghistory -------------------------------- #
 
-    def history_add(self, paths: list[PathBytes]) -> None:
+    def history_add(self, paths: list[Path]) -> None:
         """Add the paths to the history."""
         with self as state:
             state.taghistory.add(tuple(paths))

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -8,8 +8,9 @@ import time
 from collections import defaultdict
 from collections.abc import Callable
 from functools import cached_property
+from pathlib import Path
 from tempfile import mkdtemp
-from typing import TYPE_CHECKING, Any, AnyStr
+from typing import TYPE_CHECKING, Any
 
 import mediafile
 
@@ -1264,16 +1265,20 @@ class ImportTaskFactory:
         single track when `toppath` is a file, a single directory in
         `flat` mode.
         """
+        toppath_path = Path(os.fsdecode(self.toppath))
         if not os.path.isdir(util.syspath(self.toppath)):
             yield [self.toppath], [self.toppath]
         elif self.session.config["flat"]:
-            paths = []
-            for dirs, paths_in_dir in albums_in_dir(self.toppath):
-                paths += paths_in_dir
-            yield [self.toppath], paths
+            byte_paths = []
+            for _, paths_in_dir in albums_in_dir(toppath_path):
+                byte_paths += list(map(os.fsencode, paths_in_dir))
+            yield [self.toppath], byte_paths
         else:
-            for dirs, paths in albums_in_dir(self.toppath):
-                yield dirs, paths
+            for dirs, paths in albums_in_dir(toppath_path):
+                yield (
+                    list(map(os.fsencode, dirs)),
+                    list(map(os.fsencode, paths)),
+                )
 
     def singleton(self, path: util.PathBytes) -> SingletonImportTask | None:
         """Return a `SingletonImportTask` for the music file."""
@@ -1389,65 +1394,47 @@ _MULTIDISC_MARKERS = (
     r"vinyl",
 )
 
-MULTIDISC_BYTES_PATTERNS = [
-    re.compile(rf"^(.*{marker}[\W_]*)\d".encode(), re.I)
-    for marker in _MULTIDISC_MARKERS
-]
-
 MULTIDISC_PATTERNS = [
     re.compile(rf"^(.*{marker}[\W_]*)\d", re.I) for marker in _MULTIDISC_MARKERS
 ]
 
 
-def is_subdir_of_any_in_list(path: AnyStr, dirs: list[AnyStr]) -> bool:
+def is_subdir_of_any_in_list(path: Path, dirs: list[Path]) -> bool:
     """Returns True if path os a subdirectory of any directory in dirs
     (a list). In other case, returns False.
     """
-    ancestors = util.ancestry(path)
+    ancestors = path.parents
     return any(d in ancestors for d in dirs)
 
 
-def albums_in_dir(path: AnyStr) -> Iterable[tuple[list[AnyStr], list[AnyStr]]]:
+def albums_in_dir(path: Path) -> Iterable[tuple[list[Path], list[Path]]]:
     """Recursively searches the given directory and returns an iterable
     of (paths, items) where paths is a list of directories and items is
     a list of Items that is probably an album. Specifically, any folder
     containing any media files is an album.
     """
-    collapse_paths: list[AnyStr] = []
-    collapse_items: list[AnyStr] = []
+    collapse_paths: list[Path] = []
+    collapse_items: list[Path] = []
     collapse_pat = None
 
-    _ignore = config["ignore"].as_str_seq()
-    ignore: list[AnyStr]
-    if isinstance(path, str):
-        ignore = _ignore
-    else:
-        ignore = list(map(os.fsencode, _ignore))
+    ignore = config["ignore"].as_str_seq()
     ignore_hidden: bool = config["ignore_hidden"].get(bool)
 
-    patterns = (
-        MULTIDISC_PATTERNS
-        if isinstance(path, str)
-        else MULTIDISC_BYTES_PATTERNS
-    )
-
-    def get_numbered_variant_pattern(string: AnyStr) -> re.Pattern[AnyStr]:
-        pat = rf"^{re.escape(os.fsdecode(string))}\d"
-        return re.compile(
-            pat if isinstance(string, str) else os.fsencode(pat), re.I
-        )
+    def get_numbered_variant_pattern(string: str) -> re.Pattern[str]:
+        pat = rf"^{re.escape(string)}\d"
+        return re.compile(pat, re.I)
 
     for root, dirs, files in util.sorted_walk(
         path, ignore=ignore, ignore_hidden=ignore_hidden, logger=log
     ):
-        items = [os.path.join(root, f) for f in files]
+        items = [root / f for f in files]
         # If we're currently collapsing the constituent directories in a
         # multi-disc album, check whether we should continue collapsing
         # and add the current directory. If so, just add the directory
         # and move on to the next directory. If not, stop collapsing.
         if collapse_paths:
             if (is_subdir_of_any_in_list(root, collapse_paths)) or (
-                collapse_pat and collapse_pat.match(os.path.basename(root))
+                collapse_pat and collapse_pat.match(root.name)
             ):
                 # Still collapsing.
                 collapse_paths.append(root)
@@ -1466,7 +1453,7 @@ def albums_in_dir(path: AnyStr) -> Iterable[tuple[list[AnyStr], list[AnyStr]]]:
         # 1") or it contains no items but only directories that are
         # named in this way.
         start_collapsing = False
-        for marker_pat in patterns:
+        for marker_pat in MULTIDISC_PATTERNS:
             # Is this directory the root of a nested multi-disc album?
             if dirs and not items:
                 # Check whether all subdirectories have the same prefix.
@@ -1475,8 +1462,9 @@ def albums_in_dir(path: AnyStr) -> Iterable[tuple[list[AnyStr], list[AnyStr]]]:
                 for subdir in dirs:
                     # The first directory dictates the pattern for
                     # the remaining directories.
+                    subdir_str = str(subdir)
                     if not subdir_pat:
-                        match = marker_pat.match(subdir)
+                        match = marker_pat.match(subdir_str)
                         if match:
                             subdir_pat = get_numbered_variant_pattern(match[1])
                         else:
@@ -1484,7 +1472,7 @@ def albums_in_dir(path: AnyStr) -> Iterable[tuple[list[AnyStr], list[AnyStr]]]:
                             break
 
                     # Subsequent directories must match the pattern.
-                    elif not subdir_pat.match(subdir):
+                    elif not subdir_pat.match(subdir_str):
                         start_collapsing = False
                         break
 

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -171,14 +171,14 @@ class BaseImportTask:
     Tasks flow through the importer pipeline. Each stage can update
     them."""
 
-    toppath: util.PathBytes | None
-    paths: list[util.PathBytes]
+    toppath: Path | None
+    paths: list[Path]
     items: list[library.Item]
 
     def __init__(
         self,
-        toppath: util.PathBytes | None,
-        paths: Iterable[util.PathBytes] | None,
+        toppath: Path | None,
+        paths: Iterable[Path] | None,
         items: Iterable[library.Item] | None,
     ) -> None:
         """Create a task. The primary fields that define a task are:
@@ -257,8 +257,8 @@ class ImportTask(BaseImportTask):
 
     def __init__(
         self,
-        toppath: util.PathBytes | None,
-        paths: Iterable[util.PathBytes] | None,
+        toppath: Path | None,
+        paths: Iterable[Path] | None,
         items: Iterable[library.Item] | None,
     ) -> None:
         super().__init__(toppath, paths, items)
@@ -519,7 +519,7 @@ class ImportTask(BaseImportTask):
 
         # When copying and deleting originals, delete old files.
         if copy and delete:
-            new_paths = [os.path.realpath(item.path) for item in items]
+            new_paths = [item.filepath for item in items]
             for old_path in self.old_paths:
                 # Only delete files that were actually copied.
                 if old_path not in new_paths:
@@ -654,13 +654,13 @@ class ImportTask(BaseImportTask):
         items = self.imported_items()
         # Save the original paths of all items for deletion and pruning
         # in the next step (finalization).
-        self.old_paths: list[util.PathBytes] = [item.path for item in items]
+        self.old_paths: list[Path] = [item.filepath for item in items]
         for item in items:
             if operation is not None:
                 # In copy and link modes, treat re-imports specially:
                 # move in-library files. (Out-of-library files are
                 # copied/moved as usual).
-                old_path = item.path
+                old_path = item.filepath
                 if (
                     operation != util.MoveOperation.MOVE
                     and self.replaced_items[item]
@@ -709,9 +709,7 @@ class ImportTask(BaseImportTask):
         and `replaced_albums` dictionaries.
         """
         self.replaced_items = defaultdict(list)
-        self.replaced_albums: dict[util.PathBytes, library.Album] = (
-            defaultdict()
-        )
+        self.replaced_albums: dict[Path, library.Album] = defaultdict()
         replaced_album_ids = set()
         for item in self.imported_items():
             dup_items = list(lib.items(query=PathQuery("path", item.path)))
@@ -725,7 +723,9 @@ class ImportTask(BaseImportTask):
                 replaced_album = dup_item._cached_album
                 if replaced_album:
                     replaced_album_ids.add(dup_item.album_id)
-                    self.replaced_albums[replaced_album.path] = replaced_album
+                    self.replaced_albums[replaced_album.filepath] = (
+                        replaced_album
+                    )
 
     def reimport_metadata(self, lib: library.Library) -> None:
         """For reimports, preserves metadata for reimported items and
@@ -764,7 +764,7 @@ class ImportTask(BaseImportTask):
             return existing_fields
 
         if self.is_album:
-            replaced_album = self.replaced_albums.get(self.album.path)
+            replaced_album = self.replaced_albums.get(self.album.filepath)
             if replaced_album:
                 album_fields = _reduce_and_log(
                     self.album,
@@ -837,16 +837,16 @@ class ImportTask(BaseImportTask):
 
     # Utilities.
 
-    def prune(self, filename: util.PathLike) -> None:
+    def prune(self, filename: Path) -> None:
         """Prune any empty directories above the given file. If this
         task has no `toppath` or the file path provided is not within
         the `toppath`, then this function has no effect. Similarly, if
         the file still exists, no pruning is performed, so it's safe to
         call when the file in question may not have been removed.
         """
-        if self.toppath and not os.path.exists(util.syspath(filename)):
+        if self.toppath and not filename.exists():
             util.prune_dirs(
-                os.path.dirname(os.fsdecode(filename)),
+                filename.parent,
                 self.toppath,
                 clutter=config["clutter"].as_str_seq(),
             )
@@ -859,13 +859,11 @@ class SingletonImportTask(ImportTask):
     def source(self) -> Source:
         return Source.from_item(self.item)
 
-    def __init__(
-        self, toppath: util.PathBytes | None, item: library.Item
-    ) -> None:
-        super().__init__(toppath, [item.path], [item])
+    def __init__(self, toppath: Path | None, item: library.Item) -> None:
+        super().__init__(toppath, [item.filepath], [item])
         self.item = item
         self.is_album = False
-        self.paths = [item.path]
+        self.paths = [item.filepath]
 
     def imported_items(self) -> list[library.Item]:
         return [self.item]
@@ -1004,9 +1002,7 @@ class SentinelImportTask(ImportTask):
     """
 
     def __init__(
-        self,
-        toppath: util.PathBytes | None,
-        paths: Iterable[util.PathBytes] | None,
+        self, toppath: Path | None, paths: Iterable[Path] | None
     ) -> None:
         super().__init__(toppath, paths, ())
         # TODO Remove the remaining attributes eventually
@@ -1060,9 +1056,9 @@ class ArchiveImportTask(SentinelImportTask):
       non-move modes.
     """
 
-    toppath: util.PathBytes
+    toppath: Path
 
-    def __init__(self, toppath: util.PathBytes) -> None:
+    def __init__(self, toppath: Path) -> None:
         super().__init__(toppath, ())
         self.extracted = False
         # ``extract()`` reassigns ``self.toppath`` to the temp extraction
@@ -1071,15 +1067,15 @@ class ArchiveImportTask(SentinelImportTask):
         self.archive_path = toppath
 
     @classmethod
-    def is_archive(cls, path: str) -> bool:
+    def is_archive(cls, path: Path) -> bool:
         """Returns true if the given path points to an archive that can
         be handled.
         """
-        if not os.path.isfile(path):
+        if not path.is_file():
             return False
 
         for path_test, _ in cls.handlers:
-            if path_test(os.fsdecode(path)):
+            if path_test(path):
                 return True
         return False
 
@@ -1127,26 +1123,17 @@ class ArchiveImportTask(SentinelImportTask):
         if not self.extracted:
             return
 
-        all_files_imported = move and not any(
-            files for _, _, files in os.walk(util.syspath(self.toppath))
-        )
+        all_files_imported = move and not any(self.toppath.rglob("*"))
 
-        log.debug(
-            "Removing extracted directory: {}",
-            util.displayable_path(self.toppath),
-        )
-        shutil.rmtree(util.syspath(self.toppath))
+        log.debug("Removing extracted directory: {}", self.toppath)
+        shutil.rmtree(self.toppath)
 
         if all_files_imported:
-            log.debug(
-                "Removing imported archive: {}",
-                util.displayable_path(self.archive_path),
-            )
+            log.debug("Removing imported archive: {}", self.archive_path)
             util.remove(self.archive_path)
         elif move:
             log.debug(
-                "Not removing partially imported archive: {}",
-                util.displayable_path(self.archive_path),
+                "Not removing partially imported archive: {}", self.archive_path
             )
 
     def extract(self) -> None:
@@ -1156,14 +1143,12 @@ class ArchiveImportTask(SentinelImportTask):
         assert self.toppath is not None, "toppath must be set"
 
         for path_test, handler_class in self.handlers:
-            if path_test(os.fsdecode(self.toppath)):
+            if path_test(self.toppath):
                 break
         else:
-            raise ValueError(
-                f"No handler found for archive: {util.displayable_path(self.toppath)}"
-            )
-        extract_to = mkdtemp()
-        archive = handler_class(os.fsdecode(self.toppath), mode="r")
+            raise ValueError(f"No handler found for archive: {self.toppath}")
+        extract_to = Path(mkdtemp())
+        archive = handler_class(self.toppath, mode="r")
         try:
             archive.extractall(extract_to)
 
@@ -1176,13 +1161,13 @@ class ArchiveImportTask(SentinelImportTask):
                 # function time.mktime expects a 9-element tuple.
                 # The -1 indicates that the DST flag is unknown.
                 date_time = time.mktime((*f.date_time, 0, 0, -1))
-                fullpath = os.path.join(extract_to, f.filename)
+                fullpath = extract_to / f.filename
                 os.utime(fullpath, (date_time, date_time))
 
         finally:
             archive.close()
         self.extracted = True
-        self.toppath = os.fsencode(extract_to)
+        self.toppath = extract_to
 
 
 class ImportTaskFactory:
@@ -1190,7 +1175,7 @@ class ImportTaskFactory:
     indicated by a path.
     """
 
-    def __init__(self, toppath: util.PathBytes, session: ImportSession) -> None:
+    def __init__(self, toppath: Path, session: ImportSession) -> None:
         """Create a new task factory.
 
         `toppath` is the user-specified path to search for music to
@@ -1201,7 +1186,7 @@ class ImportTaskFactory:
         self.session = session
         self.skipped = 0  # Skipped due to incremental/resume.
         self.imported = 0  # "Real" tasks created.
-        self.is_archive = ArchiveImportTask.is_archive(util.syspath(toppath))
+        self.is_archive = ArchiveImportTask.is_archive(toppath)
 
     def tasks(self) -> Iterable[ImportTask]:
         """Yield all import tasks for music found in the user-specified
@@ -1254,9 +1239,7 @@ class ImportTaskFactory:
             return tasks
         return []
 
-    def paths(
-        self,
-    ) -> Iterable[tuple[list[util.PathBytes], list[util.PathBytes]]]:
+    def paths(self) -> Iterable[tuple[list[Path], list[Path]]]:
         """Walk `self.toppath` and yield `(dirs, files)` pairs where
         `files` are individual music files and `dirs` the set of
         containing directories where the music was found.
@@ -1265,28 +1248,21 @@ class ImportTaskFactory:
         single track when `toppath` is a file, a single directory in
         `flat` mode.
         """
-        toppath_path = Path(os.fsdecode(self.toppath))
-        if not os.path.isdir(util.syspath(self.toppath)):
+        if not self.toppath.is_dir():
             yield [self.toppath], [self.toppath]
         elif self.session.config["flat"]:
-            byte_paths = []
-            for _, paths_in_dir in albums_in_dir(toppath_path):
-                byte_paths += list(map(os.fsencode, paths_in_dir))
-            yield [self.toppath], byte_paths
+            paths = []
+            for _, paths_in_dir in albums_in_dir(self.toppath):
+                paths += paths_in_dir
+            yield [self.toppath], paths
         else:
-            for dirs, paths in albums_in_dir(toppath_path):
-                yield (
-                    list(map(os.fsencode, dirs)),
-                    list(map(os.fsencode, paths)),
-                )
+            for dirs, paths in albums_in_dir(self.toppath):
+                yield dirs, paths
 
-    def singleton(self, path: util.PathBytes) -> SingletonImportTask | None:
+    def singleton(self, path: Path) -> SingletonImportTask | None:
         """Return a `SingletonImportTask` for the music file."""
         if self.session.already_imported(self.toppath, [path]):
-            log.debug(
-                "Skipping previously-imported path: {}",
-                util.displayable_path(path),
-            )
+            log.debug("Skipping previously-imported path: {}", path)
             self.skipped += 1
             return None
 
@@ -1296,7 +1272,7 @@ class ImportTaskFactory:
         return None
 
     def album(
-        self, paths: Iterable[util.PathBytes], dirs: list[util.PathBytes]
+        self, paths: Iterable[Path], dirs: list[Path]
     ) -> ImportTask | None:
         """Return a `ImportTask` with all media files from paths.
 
@@ -1320,7 +1296,7 @@ class ImportTaskFactory:
         return None
 
     def sentinel(
-        self, paths: Iterable[util.PathBytes] | None = None
+        self, paths: Iterable[Path] | None = None
     ) -> SentinelImportTask:
         """Return a `SentinelImportTask` indicating the end of a
         top-level directory import.
@@ -1343,7 +1319,7 @@ class ImportTaskFactory:
             )
             return None
 
-        log.debug("Extracting archive: {}", util.displayable_path(self.toppath))
+        log.debug("Extracting archive: {}", self.toppath)
         archive_task = ArchiveImportTask(self.toppath)
         try:
             archive_task.extract()
@@ -1356,7 +1332,7 @@ class ImportTaskFactory:
         log.debug("Archive extracted to: {.toppath}", self)
         return archive_task
 
-    def read_item(self, path: util.PathBytes) -> library.Item | None:
+    def read_item(self, path: Path) -> library.Item | None:
         """Return an `Item` read from the path.
 
         If an item cannot be read, return `None` instead and log an
@@ -1365,16 +1341,13 @@ class ImportTaskFactory:
 
         # Check if the file has an extension,
         # Add an extension if there isn't one.
-        if os.path.isfile(path):
+        if path.is_file():
             path = extension.fix_extension(path, logger=log)
 
         if config["import"]["remux_mp3_in_wav"].get(bool):
             mp3_path = remux_mpeglayer3_wav(path)
             if mp3_path:
-                log.info(
-                    "Remuxed MPEGLAYER3 WAV to MP3: {}",
-                    util.displayable_path(mp3_path),
-                )
+                log.info("Remuxed MPEGLAYER3 WAV to MP3: {}", mp3_path)
                 path = mp3_path
 
         try:
@@ -1482,7 +1455,7 @@ def albums_in_dir(path: Path) -> Iterable[tuple[list[Path], list[Path]]]:
                     break
 
             # Is this directory the first in a flattened multi-disc album?
-            elif match := marker_pat.match(os.path.basename(root)):
+            elif match := marker_pat.match(root.name):
                 start_collapsing = True
                 # Set the current pattern to match directories with the same
                 # prefix as this one, followed by a digit.

--- a/beets/test/_common.py
+++ b/beets/test/_common.py
@@ -83,7 +83,7 @@ def item(lib: Library | None = None, **kwargs) -> Item:
 def import_session(
     lib: Library,
     loghandler: logging.Handler | None = None,
-    paths: Sequence[bytes] | None = None,
+    paths: Sequence[Path] | None = None,
     query: str | Sequence[str] | Query | None = None,
     cli: bool = False,
 ) -> importer.ImportSession:

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -591,10 +591,7 @@ class ImporterMixin(PathsMixin, ConfigMixin):
 
     def _get_import_session(self, import_dir: Path) -> ImportSession:
         return ImportSessionFixture(
-            self.lib,
-            loghandler=None,
-            query=None,
-            paths=[os.fsencode(import_dir)],
+            self.lib, loghandler=None, query=None, paths=[import_dir]
         )
 
     def setup_importer(
@@ -751,7 +748,7 @@ class TerminalImportMixin(IOMixin, ImportHelper):
             loghandler=None,
             query=None,
             io=self.request.getfixturevalue("io"),
-            paths=[os.fsencode(import_dir)],
+            paths=[import_dir],
         )
 
 

--- a/beets/ui/commands/import_/__init__.py
+++ b/beets/ui/commands/import_/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 from beets import config, logging, plugins, ui
@@ -28,7 +29,7 @@ class ImportCLIOpts(Protocol):
     from_logfiles: list[str] | None
 
 
-def paths_from_logfile(path: str) -> Iterator[str]:
+def paths_from_logfile(path: str) -> Iterator[Path]:
     """Parse the logfile and yield skipped paths to pass to the `import`
     command.
     """
@@ -45,10 +46,10 @@ def paths_from_logfile(path: str) -> Iterator[str]:
             if verb not in {"asis", "skip", "duplicate-skip"}:
                 raise ValueError(f"line {i} contains unknown verb {verb}")
 
-            yield os.path.commonpath(paths.split("; "))
+            yield (normpath(Path(os.path.commonpath(paths.split("; ")))))
 
 
-def parse_logfiles(logfiles: list[str]) -> Iterator[str]:
+def parse_logfiles(logfiles: list[str]) -> Iterator[Path]:
     """Parse all `logfiles` and yield paths from it."""
     for logfile in logfiles:
         try:
@@ -64,7 +65,7 @@ def parse_logfiles(logfiles: list[str]) -> Iterator[str]:
 
 
 def import_files(
-    lib: Library, paths: list[bytes], query: list[str] | None
+    lib: Library, paths: list[Path], query: list[str] | None
 ) -> None:
     """Import the files in the given list of paths or matching the
     query.
@@ -107,10 +108,10 @@ def import_func(lib: Library, opts: ImportCLIOpts, args: list[str]) -> None:
 
     if opts.library:
         query = args
-        byte_paths = []
+        paths = []
     else:
         query = None
-        paths = args
+        paths = list(map(Path, args))
 
         # The paths from the logfiles go into a separate list to allow handling
         # errors differently from user-specified paths.
@@ -119,35 +120,28 @@ def import_func(lib: Library, opts: ImportCLIOpts, args: list[str]) -> None:
         if not paths and not paths_from_logfiles:
             raise UserError("no path specified")
 
-        byte_paths = [os.fsencode(p) for p in paths]
-        byte_paths_from_logfiles = [os.fsencode(p) for p in paths_from_logfiles]
-
         # Check the user-specified directories.
-        for path in byte_paths:
-            if not os.path.exists(syspath(normpath(path))):
-                raise UserError(
-                    f"no such file or directory: {displayable_path(path)}"
-                )
+        for path in paths:
+            if not path.exists():
+                raise UserError(f"no such file or directory: {path}")
 
         # Check the directories from the logfiles, but don't throw an error in
         # case those paths don't exist. Maybe some of those paths have already
         # been imported and moved separately, so logging a warning should
         # suffice.
-        for path in byte_paths_from_logfiles:
-            if not os.path.exists(syspath(normpath(path))):
-                log.warning(
-                    "No such file or directory: {}", displayable_path(path)
-                )
+        for path in paths_from_logfiles:
+            if not path.exists():
+                log.warning("No such file or directory: {}", path)
                 continue
 
-            byte_paths.append(path)
+            paths.append(path)
 
         # If all paths were read from a logfile, and none of them exist, throw
         # an error
-        if not byte_paths:
+        if not paths:
             raise UserError("none of the paths are importable")
 
-    import_files(lib, byte_paths, query)
+    import_files(lib, paths, query)
 
 
 def _store_dict(

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -22,11 +22,11 @@ from .display import show_change, show_item_change
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
 
     from beets.autotag import Proposal, Source
     from beets.importer import ImportSession, ImportTask
     from beets.library import AlbumOrItem, Item
-    from beets.util import PathBytes
 
 # Global logger.
 log = logging.getLogger("beets")
@@ -213,10 +213,9 @@ class TerminalImportSession(importer.ImportSession):
 
         return action
 
-    def should_resume(self, path: PathBytes) -> bool:
+    def should_resume(self, path: Path) -> bool:
         return ui.input_yn(
-            f"Import of the directory:\n{displayable_path(path)}\n"
-            "was interrupted. Resume (Y/n)?"
+            f"Import of the directory:\n{path}\nwas interrupted. Resume (Y/n)?"
         )
 
     def _get_choices(self, task: ImportTask) -> list[PromptChoice]:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -54,14 +54,9 @@ if TYPE_CHECKING:
 MAX_FILENAME_LENGTH = 200
 WINDOWS_MAGIC_PREFIX = "\\\\?\\"
 T = TypeVar("T")
-AnyPath = TypeVar("AnyPath", str, bytes, Path)
 StrPath = str | Path
 PathLike = StrPath | bytes
 Replacements = Sequence[tuple[Pattern[str], str]]
-
-# Here for now to allow for a easy replace later on
-# once we can move to a PathLike (mainly used in importer)
-PathBytes = bytes
 
 
 class HumanReadableError(Exception):

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -218,11 +218,11 @@ def ancestry(path: AnyStr) -> list[AnyStr]:
 
 
 def sorted_walk(
-    path: AnyStr,
-    ignore: Sequence[AnyStr] = (),
+    path: Path,
+    ignore: Sequence[str] = (),
     ignore_hidden: bool = False,
     logger: Logger | None = None,
-) -> Iterator[tuple[AnyStr, Sequence[AnyStr], Sequence[AnyStr]]]:
+) -> Iterator[tuple[Path, Sequence[Path], Sequence[Path]]]:
     """Like `os.walk`, but yields things in case-insensitive sorted,
     breadth-first order.  Directory and file names matching any glob
     pattern in `ignore` are skipped. If `logger` is provided, then
@@ -230,49 +230,44 @@ def sorted_walk(
     """
     # Get all the directories and files at this level.
     try:
-        contents = os.listdir(path)
+        entries = path.iterdir()
     except OSError:
         if logger:
-            logger.warning(
-                "could not list directory {}",
-                displayable_path(path),
-                exc_info=True,
-            )
+            logger.warning("could not list directory {}", path, exc_info=True)
         return
     dirs = []
     files = []
-    for base in contents:
+    for entry in entries:
         # Skip ignored filenames.
-        skip = False
-        for pat in ignore:
-            if fnmatch.fnmatch(base, pat):
-                if logger:
-                    logger.debug(
-                        "ignoring '{}' due to ignore rule '{}'", base, pat
-                    )
-                skip = True
-                break
-        if skip:
+        if any(entry.match(pat) for pat in ignore):
+            if logger:
+                logger.debug(
+                    "ignoring '{}' due to ignore rule '{}'",
+                    entry.name,
+                    next(pat for pat in ignore if entry.match(pat)),
+                )
+            continue
+
+        if ignore_hidden and hidden.is_hidden(entry):
             continue
 
         # Add to output as either a file or a directory.
-        cur = os.path.join(path, base)
-        if (ignore_hidden and not hidden.is_hidden(cur)) or not ignore_hidden:
-            if os.path.isdir(syspath(cur)):
-                dirs.append(base)
-            else:
-                files.append(base)
+        if entry.is_dir():
+            dirs.append(entry)
+        else:
+            files.append(entry)
 
     # Sort lists (case-insensitive) and yield the current level.
-    sort_key = path.__class__.lower
-    dirs.sort(key=sort_key)
-    files.sort(key=sort_key)
-    yield (path, dirs, files)
+    dirs.sort(key=lambda p: p.name.lower())
+    files.sort(key=lambda p: p.name.lower())
+    yield (
+        path,
+        [d.relative_to(path) for d in dirs],
+        [f.relative_to(path) for f in files],
+    )
 
-    # Recurse into directories.
-    for base in dirs:
-        cur = os.path.join(path, base)
-        yield from sorted_walk(cur, ignore, ignore_hidden, logger)
+    for dir_path in dirs:
+        yield from sorted_walk(dir_path, ignore, ignore_hidden, logger)
 
 
 def path_as_posix(path: bytes) -> bytes:

--- a/beets/util/extension.py
+++ b/beets/util/extension.py
@@ -6,19 +6,14 @@ import os
 import subprocess
 from logging import Logger
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import mutagen.wave
 
 import beets
 from beets import util
 
-if TYPE_CHECKING:
-    from beets.util import AnyPath
-
 logger = Logger.info
 
-PathBytes = bytes
 PATH_SEP: bytes = util.bytestring_path(os.sep)
 
 # a list of audio formats I got from wikipedia https://en.wikipedia.org/wiki/Audio_file_format
@@ -72,7 +67,7 @@ AUDIO_EXTENSIONS = {
 }
 
 
-def fix_extension(path_bytes: PathBytes, logger: Logger | None = None) -> bytes:
+def fix_extension(path: Path, logger: Logger | None = None) -> Path:
     """Return the `path` after adding an appropriate extension if needed.
 
     If the file already has an extension, return as-is.
@@ -80,10 +75,9 @@ def fix_extension(path_bytes: PathBytes, logger: Logger | None = None) -> bytes:
     If the file is not a music format, return as-is.
     If the format is found, return path with extension.
     """
-    path = Path(os.fsdecode(path_bytes))
     # if there is an extension, return unchanged
     if path.suffix != "":
-        return path_bytes
+        return path
 
     # no extension detected
     # use ffprobe to find the format
@@ -127,7 +121,7 @@ def fix_extension(path_bytes: PathBytes, logger: Logger | None = None) -> bytes:
 
     # if ffprobe can't find a format, the file is prob not music
     if detected_format == "":
-        return path_bytes
+        return path
 
     # cp and add ext. If already exist, use that file
     # assume, for example, the only diff between 'asdf.mp3' and 'asdf' is format
@@ -140,10 +134,10 @@ def fix_extension(path_bytes: PathBytes, logger: Logger | None = None) -> bytes:
     else:
         if logger:
             logger.info("Import file with matching format to original target")
-    return os.fsencode(new_path)
+    return new_path
 
 
-def remux_mpeglayer3_wav(path: AnyPath) -> AnyPath | None:
+def remux_mpeglayer3_wav(path: Path) -> Path | None:
     """If 'path' is a WAV file containing an MP3 stream
     (WAVE_FORMAT_MPEGLAYER3, wFormatTag = 0x0055), extract the MP3 stream
     to a new .mp3 file and return its path. Returns None if the file is not
@@ -172,8 +166,4 @@ def remux_mpeglayer3_wav(path: AnyPath) -> AnyPath | None:
 
     util.remove(path)
 
-    if isinstance(path, str):
-        return str(mp3_path)
-    if isinstance(path, bytes):
-        return os.fsencode(mp3_path)
     return mp3_path

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 _fs_lock = threading.Lock()
 # Keep track of temporary transcoded files for deletion.
-_temp_files: list[bytes] = []
+_temp_files: list[Path] = []
 
 
 class ConvertCLIOpts(Protocol):
@@ -738,7 +738,8 @@ class ConvertPlugin(BeetsPlugin):
             fd, dest = tempfile.mkstemp(b"." + ext, dir=tmpdir)
             os.close(fd)
             dest = util.bytestring_path(dest)
-            _temp_files.append(dest)  # Delete the transcode later.
+            # Delete the transcode later.
+            _temp_files.append(Path(os.fsdecode(dest)))
 
             # Convert.
             try:
@@ -785,7 +786,7 @@ class ConvertPlugin(BeetsPlugin):
     def _cleanup(self, task: ImportTask, session: ImportSession) -> None:
         for path in task.old_paths:
             if path in _temp_files:
-                if os.path.isfile(util.syspath(path)):
+                if path.is_file():
                     util.remove(path)
                 _temp_files.remove(path)
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1050,13 +1050,10 @@ class FileSystem(LocalArtSource):
             images = [
                 fn_path
                 for root, _, files in sorted_walk(
-                    str(path), ignore=ignore, ignore_hidden=ignore_hidden
+                    path, ignore=ignore, ignore_hidden=ignore_hidden
                 )
                 for fn in files
-                if (
-                    (fn_path := Path(path) / fn).suffix.lower()
-                    in IMAGE_EXTENSIONS
-                )
+                if ((fn_path := path / fn).suffix.lower() in IMAGE_EXTENSIONS)
                 and fn_path.is_file()
             ]
 

--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -1,4 +1,4 @@
-"""Populate an item's `added` and `mtime` fields by using the file
+"""Populate an item's `added` and `mtime` fields by using the fileimportadd
 modification time (mtime) of the item's source file before import.
 
 Reimported albums and items are skipped.
@@ -13,6 +13,8 @@ from beets import importer, util
 from beets.plugins import BeetsPlugin
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from beets.importer import ImportSession, ImportTask
     from beets.library import Album, Item, Library
 
@@ -20,7 +22,7 @@ if TYPE_CHECKING:
 class ImportAddedPlugin(BeetsPlugin):
     item_mtime: dict[bytes, float]
     reimported_item_ids: set[int | None]
-    replaced_album_paths: set[bytes]
+    replaced_album_paths: set[Path]
 
     def __init__(self) -> None:
         super().__init__()
@@ -58,7 +60,7 @@ class ImportAddedPlugin(BeetsPlugin):
         return item.id in self.reimported_item_ids
 
     def reimported_album(self, album: Album) -> bool:
-        return album.path in self.replaced_album_paths
+        return album.filepath in self.replaced_album_paths
 
     def record_if_inplace(
         self, task: ImportTask, session: ImportSession

--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 from beets import ui
 from beets.autotag import Recommendation
 from beets.plugins import BeetsPlugin
-from beets.util import PromptChoice, displayable_path
+from beets.util import PromptChoice
 
 if TYPE_CHECKING:
     import optparse
@@ -65,7 +65,7 @@ class MBSubmitPlugin(BeetsPlugin):
     def picard(self, session: ImportSession, task: ImportTask) -> None:
         paths = []
         for p in task.paths:
-            paths.append(displayable_path(p))
+            paths.append(p)
         try:
             picard_path = self.config["picard_path"].as_str()
             subprocess.Popen([picard_path, *paths])

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -1579,7 +1579,7 @@ class ReplayGainPlugin(BeetsPlugin):
         ):
             self.open_pool(threads)
 
-    def import_end(self, lib: Library, paths: list[bytes]) -> None:
+    def import_end(self, lib: Library, paths: list[Path]) -> None:
         """Handle `import` event -> close pool"""
         self.close_pool()
 

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -83,7 +83,7 @@ class TestImportConvert(AsIsImporterMixin, ImportHelper, ConvertPluginHelper):
         for path in self.importer.paths:
             for root, dirnames, filenames in os.walk(path):
                 assert len(fnmatch.filter(filenames, "*.mp3")) == 0, (
-                    f"Non-empty import directory {util.displayable_path(path)}"
+                    f"Non-empty import directory {path}"
                 )
 
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1740,7 +1740,7 @@ class AlbumsInDirTest(BeetsTestCase):
         _mkmp3(album2_dir / "album2song.mp3")
         _mkmp3(album3_dir / "album3song.mp3")
         _mkmp3(album4_dir / "album4song.mp3")
-        self.base = str(base)
+        self.base = base
 
     def test_finds_all_albums(self):
         albums = list(albums_in_dir(self.base))
@@ -1749,7 +1749,7 @@ class AlbumsInDirTest(BeetsTestCase):
     def test_separates_contents(self):
         found = []
         for _, album in albums_in_dir(self.base):
-            found.append(re.search(r"album(.)song", album[0]).group(1))
+            found.append(re.search(r"album(.)song", str(album[0])).group(1))
         assert "1" in found
         assert "2" in found
         assert "3" in found
@@ -1757,7 +1757,7 @@ class AlbumsInDirTest(BeetsTestCase):
 
     def test_finds_multiple_songs(self):
         for _, album in albums_in_dir(self.base):
-            n = re.search(r"album(.)song", album[0]).group(1)
+            n = re.search(r"album(.)song", str(album[0])).group(1)
             if n == "1":
                 assert len(album) == 2
             else:
@@ -1808,10 +1808,6 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
         if files:
             for path in self.files:
                 _mkmp3(path)
-
-        self.dirs = list(map(str, self.dirs))
-        self.files = list(map(str, self.files))
-        self.base = str(self.base)
 
     def _normalize_path(self, path: Path) -> Path:
         """Normalize a path's Unicode combining form according to the
@@ -1896,9 +1892,9 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
                     disc = album_dir / f"{marker}{suffix}"
                     disc.mkdir()
                     _mkmp3(disc / "song.mp3")
-                    discs.append(str(disc))
+                    discs.append(disc)
 
-                albums = list(albums_in_dir(str(base)))
+                albums = list(albums_in_dir(base))
                 assert len(albums) == 1
                 root, items = albums[0]
                 for disc in discs:
@@ -1919,7 +1915,7 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
             d.mkdir()
             _mkmp3(d / "song.mp3")
 
-        albums = list(albums_in_dir(str(base)))
+        albums = list(albums_in_dir(base))
         assert len(albums) == 2
 
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -45,7 +45,7 @@ from beets.test.helper import (
     TestHelper,
     has_program,
 )
-from beets.util import bytestring_path, syspath
+from beets.util import syspath
 from beets.util.extension import remux_mpeglayer3_wav
 
 
@@ -152,14 +152,13 @@ class TestNonAutotaggedImport(PathsMixin, AsIsImporterMixin, ImportHelper):
         assert self.track_lib_path.exists()
 
 
-def create_archive(session):
-    handle, path = mkstemp(dir=session.temp_path)
-    path = bytestring_path(path)
+def create_archive(session) -> Path:
+    handle, str_path = mkstemp(dir=session.temp_path)
+    path = Path(str_path)
     os.close(handle)
-    archive = ZipFile(os.fsdecode(path), mode="w")
-    archive.write(_common.RSRC / "full.mp3", "full.mp3")
-    archive.close()
-    return bytestring_path(path)
+    with ZipFile(path, mode="w") as archive:
+        archive.write(_common.RSRC / "full.mp3", "full.mp3")
+    return path
 
 
 class TestRmTemp(TestHelper):
@@ -180,35 +179,33 @@ class TestRmTemp(TestHelper):
         zip_path = create_archive(self)
         archive_task = importer.ArchiveImportTask(zip_path)
         archive_task.extract()
-        tmp_path = Path(os.fsdecode(archive_task.toppath))
-        assert tmp_path.exists()
+        assert archive_task.toppath.exists()
         archive_task.finalize(self)
-        assert not tmp_path.exists()
+        assert not archive_task.toppath.exists()
 
     def test_archive_removed_on_move_complete(self):
         zip_path = create_archive(self)
         archive_task = importer.ArchiveImportTask(zip_path)
         archive_task.extract()
-        for root, _, files in os.walk(archive_task.toppath):
-            for f in files:
-                os.remove(os.path.join(root, f))
-        assert Path(os.fsdecode(zip_path)).exists()
+        for file in archive_task.toppath.rglob("*"):
+            file.unlink()
+        assert zip_path.exists()
         archive_task.cleanup(move=True)
-        assert not Path(os.fsdecode(zip_path)).exists()
+        assert not zip_path.exists()
 
     def test_archive_preserved_on_move_partial(self):
         zip_path = create_archive(self)
         archive_task = importer.ArchiveImportTask(zip_path)
         archive_task.extract()
         archive_task.cleanup(move=True)
-        assert Path(os.fsdecode(zip_path)).exists()
+        assert zip_path.exists()
 
     def test_archive_preserved_on_copy(self):
         zip_path = create_archive(self)
         archive_task = importer.ArchiveImportTask(zip_path)
         archive_task.extract()
         archive_task.cleanup(copy=True)
-        assert Path(os.fsdecode(zip_path)).exists()
+        assert zip_path.exists()
 
     def test_tempdir_removed_in_all_modes(self):
         for cleanup_kwargs in (
@@ -220,7 +217,7 @@ class TestRmTemp(TestHelper):
             zip_path = create_archive(self)
             archive_task = importer.ArchiveImportTask(zip_path)
             archive_task.extract()
-            tmp_path = Path(os.fsdecode(archive_task.toppath))
+            tmp_path = archive_task.toppath
             assert tmp_path.exists(), f"extract failed for {cleanup_kwargs}"
             archive_task.cleanup(**cleanup_kwargs)
             assert not tmp_path.exists(), (
@@ -241,10 +238,10 @@ class TestImportZip(AsIsImporterMixin, ImportHelper):
 
 class TestImportTar(TestImportZip):
     def create_archive(self):
-        (handle, path) = mkstemp(dir=self.temp_path)
-        path = bytestring_path(path)
+        (handle, str_path) = mkstemp(dir=self.temp_path)
+        path = Path(str_path)
         os.close(handle)
-        archive = TarFile(os.fsdecode(path), mode="w")
+        archive = TarFile(path, mode="w")
         archive.add(_common.RSRC / "full.mp3", "full.mp3")
         archive.close()
         return path
@@ -327,7 +324,7 @@ class ImportSingletonTest(AutotagImportTestCase):
         util.copy(resource_path, single_path)
         import_files = [self.import_path / "album", single_path]
         self.setup_importer()
-        self.importer.paths = list(map(os.fsencode, import_files))
+        self.importer.paths = import_files
 
         self.importer.add_choice(importer.Action.ASIS)
         self.importer.add_choice(importer.Action.ASIS)
@@ -388,7 +385,7 @@ class TestImportFormat(ImportHelper):
         resource_path = self.import_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
-        self.importer.paths = [os.fsencode(resource_path)]
+        self.importer.paths = [resource_path]
         self.importer.run()
         assert self.lib.items().get().path.endswith(b".mp3")
 
@@ -399,7 +396,7 @@ class TestImportFormat(ImportHelper):
         new_path = self.temp_path / "no_ext.mp3"
         util.copy(temp_resource_path, new_path)
         self.setup_importer(autotag=False)
-        self.importer.paths = [os.fsencode(temp_resource_path)]
+        self.importer.paths = [temp_resource_path]
         with caplog.at_level("DEBUG"):
             self.importer.run()
         assert (
@@ -411,7 +408,7 @@ class TestImportFormat(ImportHelper):
     def test_recognize_format_not_music(self):
         resource_path = _common.RSRC / "no_ext_not_music"
         self.setup_importer(autotag=False)
-        self.importer.paths = [os.fsencode(resource_path)]
+        self.importer.paths = [resource_path]
         self.importer.run()
         assert len(self.lib.items()) == 0
 
@@ -421,7 +418,7 @@ class TestImportFormat(ImportHelper):
         resource_path = self.temp_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
-        self.importer.paths = [os.fsencode(resource_path)]
+        self.importer.paths = [resource_path]
         self.importer.run()
         assert not Path(self.temp_path / "no_ext").exists()
 
@@ -431,7 +428,7 @@ class TestImportFormat(ImportHelper):
         resource_path = self.temp_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
-        self.importer.paths = [os.fsencode(resource_path)]
+        self.importer.paths = [resource_path]
         self.importer.run()
         assert Path(self.temp_path / "no_ext").exists()
 
@@ -1074,9 +1071,7 @@ class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
         # Imported item has the same albumartist and album as the one in the
         # library album. We use album metadata (not item metadata) since
         # duplicate detection uses album-level fields.
-        import_file = os.path.join(
-            self.importer.paths[0], b"album", b"track_1.mp3"
-        )
+        import_file = self.importer.paths[0] / "album" / "track_1.mp3"
         import_file = MediaFile(import_file)
         import_file.artist = album.albumartist
         import_file.albumartist = album.albumartist
@@ -1126,7 +1121,7 @@ class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
 
         item = self.lib.items().get()
         import_file = MediaFile(
-            os.path.join(self.importer.paths[0], b"album", b"track_1.mp3")
+            self.importer.paths[0] / "album" / "track_1.mp3"
         )
         import_file.artist = item["artist"]
         import_file.albumartist = item["artist"]
@@ -1267,9 +1262,7 @@ class TestImportDuplicateSingleton(ImportHelper):
         # Imported item has the same artist and title as the one in the
         # library. We use item metadata since duplicate detection uses
         # item-level fields for singletons.
-        import_file = os.path.join(
-            self.importer.paths[0], b"album", b"track_1.mp3"
-        )
+        import_file = self.importer.paths[0] / "album" / "track_1.mp3"
         import_file = MediaFile(import_file)
         import_file.artist = item.artist
         import_file.title = item.title
@@ -2183,9 +2176,7 @@ class TestImportId(ImportHelper):
     def test_candidates_album(self):
         """Test directly ImportTask.lookup_candidates()."""
         task = importer.ImportTask(
-            paths=os.fsencode(self.import_path),
-            toppath="top path",
-            items=[_common.item()],
+            paths=[self.import_path], toppath="top path", items=[_common.item()]
         )
 
         task.lookup_candidates([self.ID_RELEASE_0, self.ID_RELEASE_1])

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -371,29 +371,28 @@ class WalkTest(BeetsTestCase):
         base_d = self.base / "d"
         base_d.mkdir()
         (base_d / "z").touch()
-        self.str_base = str(self.base)
 
     def test_sorted_files(self):
-        res = list(util.sorted_walk(self.str_base))
+        res = list(util.sorted_walk(self.base))
         assert len(res) == 2
-        assert res[0] == (self.str_base, ["d"], ["x", "y"])
-        assert res[1] == (str(self.base / "d"), [], ["z"])
+        assert res[0] == (self.base, [Path("d")], [Path("x"), Path("y")])
+        assert res[1] == (self.base / Path("d"), [], [Path("z")])
 
     def test_ignore_file(self):
-        res = list(util.sorted_walk(self.str_base, ("x",)))
+        res = list(util.sorted_walk(self.base, ("x",)))
         assert len(res) == 2
-        assert res[0] == (self.str_base, ["d"], ["y"])
-        assert res[1] == (str(self.base / "d"), [], ["z"])
+        assert res[0] == (self.base, [Path("d")], [Path("y")])
+        assert res[1] == (self.base / Path("d"), [], [Path("z")])
 
     def test_ignore_directory(self):
-        res = list(util.sorted_walk(self.str_base, ("d",)))
+        res = list(util.sorted_walk(self.base, ("d",)))
         assert len(res) == 1
-        assert res[0] == (self.str_base, [], ["x", "y"])
+        assert res[0] == (self.base, [], [Path("x"), Path("y")])
 
     def test_ignore_everything(self):
-        res = list(util.sorted_walk(self.str_base, ("*",)))
+        res = list(util.sorted_walk(self.base, ("*",)))
         assert len(res) == 1
-        assert res[0] == (self.str_base, [], [])
+        assert res[0] == (self.base, [], [])
 
 
 class UniquePathTest(BeetsTestCase):

--- a/test/ui/commands/test_import.py
+++ b/test/ui/commands/test_import.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
@@ -52,7 +53,7 @@ class ImportTest(BeetsTestCase):
         logfile = self.temp_path / "logfile.log"
         logfile.write_text(logfile_content)
         actual_paths = list(paths_from_logfile(logfile))
-        assert actual_paths == expected_paths
+        assert actual_paths == list(map(Path, expected_paths))
 
 
 @patch("beets.ui.term_width", Mock(return_value=54))


### PR DESCRIPTION
Fixes #6968

- Migrates the importer stack from byte-based paths to `pathlib.Path`, centering path handling around a single, higher-level type across `beets.importer`, related UI entry points, state tracking, and importer-facing plugins.

- Extends the earlier `Path` work in directory walking by carrying `Path` objects through the full import flow: task creation, session state, archive extraction, logging, duplicate handling, resume/history tracking, and logfile path parsing.

- Simplifies importer internals by removing repeated `os.fsencode`/`os.fsdecode`/`syspath` conversions and replacing many low-level path operations with native `Path` methods like `.exists()`, `.is_file()`, `.parent`, `.name`, and `.rglob()`.

- Updates importer tests and supporting helpers to use `Path` directly, aligning the test surface with the production architecture.

- High-level impact: this reduces path-type mixing in the importer, makes path logic easier to follow, and creates a cleaner foundation for continuing the broader move away from legacy byte-path handling.
