### PR TITLE
playcount: fix various issues in listen to library track matching

### DIFF
--- a/beetsplug/_utils/playcount.py
+++ b/beetsplug/_utils/playcount.py
@@ -24,7 +24,14 @@ class Track(TypedDict):
 
 
 def get_items(lib: Library, track: Track, log: BeetsLogger) -> Sequence[Item]:
-    mbid, artist, title = track["mbid"], track["artist"], track["name"]
+    mbid = track["mbid"]
+    if mbid:
+        items = list(lib.items(MatchQuery("mb_trackid", mbid)))
+        if items:
+            # Prefer MBID if there is a match
+            return items
+
+    artist, title = track["artist"], track["name"]
     album = track.get("album") or ""
 
     log.debug("query: {} - {} ({})", artist, title, album)
@@ -39,9 +46,6 @@ def get_items(lib: Library, track: Track, log: BeetsLogger) -> Sequence[Item]:
     or_queries: list[Query] = [
         AndQuery([SubstringQuery("artist", artist), title_query])
     ]
-    # First try to query by musicbrainz's trackid
-    if mbid:
-        or_queries.append(MatchQuery("mb_trackid", mbid))
     if album:
         or_queries.append(
             AndQuery([SubstringQuery("album", album), title_query])

--- a/beetsplug/_utils/playcount.py
+++ b/beetsplug/_utils/playcount.py
@@ -43,15 +43,11 @@ def get_items(lib: Library, track: Track, log: BeetsLogger) -> Sequence[Item]:
             SubstringQuery("title", title.replace("'", "\u2019")),
         ]
     )
-    or_queries: list[Query] = [
-        AndQuery([SubstringQuery("artist", artist), title_query])
-    ]
+    or_queries: list[Query] = [SubstringQuery("artist", artist)]
     if album:
-        or_queries.append(
-            AndQuery([SubstringQuery("album", album), title_query])
-        )
+        or_queries.append(SubstringQuery("album", album))
 
-    return list(lib.items(OrQuery(or_queries)))
+    return list(lib.items(AndQuery([title_query, OrQuery(or_queries)])))
 
 
 def process_track(

--- a/beetsplug/_utils/playcount.py
+++ b/beetsplug/_utils/playcount.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, TypedDict
 from typing_extensions import NotRequired
 
 from beets.dbcore import AndQuery, MatchQuery, OrQuery
-from beets.dbcore.query import SubstringQuery
+from beets.dbcore.query import StringQuery, SubstringQuery
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -36,6 +36,24 @@ def get_items(lib: Library, track: Track, log: BeetsLogger) -> Sequence[Item]:
 
     log.debug("query: {} - {} ({})", artist, title, album)
 
+    # Try exact match first
+    title_query = OrQuery(
+        [
+            StringQuery("title", title),
+            # try a right single quotation mark instead of an apostrophe
+            StringQuery("title", title.replace("'", "\u2019")),
+        ]
+    )
+
+    or_queries: list[Query] = [StringQuery("artist", artist)]
+    if album:
+        or_queries.append(StringQuery("album", album))
+
+    items = list(lib.items(AndQuery([title_query, OrQuery(or_queries)])))
+    if items:
+        return items
+
+    # Fall back to substring matches
     title_query = OrQuery(
         [
             SubstringQuery("title", title),
@@ -43,7 +61,7 @@ def get_items(lib: Library, track: Track, log: BeetsLogger) -> Sequence[Item]:
             SubstringQuery("title", title.replace("'", "\u2019")),
         ]
     )
-    or_queries: list[Query] = [SubstringQuery("artist", artist)]
+    or_queries = [SubstringQuery("artist", artist)]
     if album:
         or_queries.append(SubstringQuery("album", album))
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -116,6 +116,13 @@ Bug fixes
   ``tarfile.TarFile`` lost its ``ZipFileCompat`` interface in Python 3 and
   ``py7zr.SevenZipFile`` exposes ``list()`` rather than ``infolist()``.
   :bug:`5664`
+- :doc:`plugins/listenbrainz` and :doc:`plugins/lastimport`: Play counts are now
+  matched more accurately. An exact MusicBrainz recording ID match is preferred
+  when one exists, and titles are matched exactly (confirmed by the artist or
+  album) before falling back to the previous substring-based matching.
+  Previously all queries were combined, so a listen for "Song" also updated
+  "Song (inst.)" or any other item whose title only contained the listened
+  title.
 
 ..
     For plugin developers

--- a/test/plugins/utils/test_playcount.py
+++ b/test/plugins/utils/test_playcount.py
@@ -97,6 +97,19 @@ class TestPlayCount(TestHelper):
 
         assert matched_ids == [item.id]
 
+    def test_get_items_mbid_match_suppresses_title_match(self, log):
+        by_mbid = self.add_item(
+            title="Song", artist="Artist", mb_trackid="track-id"
+        )
+        self.add_item(title="Song", artist="Artist", mb_trackid="other-id")
+
+        matched_ids = [
+            matched.id
+            for matched in get_items(self.lib, self.track(mbid="track-id"), log)
+        ]
+
+        assert matched_ids == [by_mbid.id]
+
     def test_process_track_updates_every_matching_song(self, log):
         first = self.add_item(
             title="Song", artist="Artist", album="First Album", play_count=1

--- a/test/plugins/utils/test_playcount.py
+++ b/test/plugins/utils/test_playcount.py
@@ -110,6 +110,27 @@ class TestPlayCount(TestHelper):
 
         assert matched_ids == [by_mbid.id]
 
+    def test_get_items_prefers_exact_match(self, log):
+        exact_match = self.add_item(title="Song", artist="Artist")
+        self.add_item(title="Song (inst.)", artist="Artist")
+
+        matched_ids = [
+            matched.id for matched in get_items(self.lib, self.track(), log)
+        ]
+
+        assert matched_ids == [exact_match.id]
+
+    def test_get_items_falls_back_to_substring_match(self, log):
+        substring_match = self.add_item(
+            title="Song (feat. Artist)", artist="Artist"
+        )
+
+        matched_ids = [
+            matched.id for matched in get_items(self.lib, self.track(), log)
+        ]
+
+        assert matched_ids == [substring_match.id]
+
     def test_process_track_updates_every_matching_song(self, log):
         first = self.add_item(
             title="Song", artist="Artist", album="First Album", play_count=1


### PR DESCRIPTION
## Description

This PR improves how listens are matched to library items in the shared `playcount` code used by the `listenbrainz` and `lastimport` plugins.

**Prefer an exact MBID match over title queries**
Previously, all matchers were simply OR'd together, so the preference for MBID matches stated in the comments wasn't really applied. Instead, listens with an MBID match could also update tracks with a different MBID, just because they had a substring match on their title. For example, a listen for "Song" would also update play counts for "Song (inst.)", even though the library already contained "Song" with the listen's exact MBID and the instrumental has a different one.

**Simplify matcher queries**
The query was previously written as `(title && artist) || (title && album)`, which is distributively the same as `title && (artist || album)`. Rewriting it clarifies the intent, where the title must match and the artist or album confirms the match.

**Prefer exact title/artist/album matches over substring matches**
Try to match the exact title and artist/album first (case-insensitive via `StringQuery`), only then fall back to the previous substring matching.

This helps in cases where multiple variants of a song with distinct listen counts exist, like "Song" and "Song (inst.)" or "Song (Japanese ver.)". This commit stops "Song" from also updating those separate variants if an exact match of "Song" exists.

Nonetheless, if the library only has an item named "Song (feat. Artist)", "Song" will still update its play count through the substring match.

### Checklist
- [X] Changelog
- [X] Tests
