### PR TITLE
docs: link ID3v2.4 spec to an archived copy (id3.org is offline)

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -307,7 +307,7 @@ missing completely.
 
 To enable ID3v2.3 tags, enable the :ref:`id3v23` config option.
 
-.. _id3v2.4: https://id3.org/id3v2.4.0-structure
+.. _id3v2.4: https://web.archive.org/web/20241227201357/https://id3.org/id3v2.4.0-structure
 
 .. _invalid:
 


### PR DESCRIPTION
The FAQ's `ID3v2.4`_ link pointed at `https://id3.org/id3v2.4.0-structure`, which is no longer reachable (connection-level failure, not a transient error). Replaced it with a Wayback Machine snapshot of the page, verified returning HTTP 200.