### PR TITLE
Restore applying Proposal results from manual search/ID.

### DIFF
--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -12,6 +12,7 @@ from .distance import Distance, distance, string_dist, track_distance
 from .hooks import AlbumInfo, Info, TrackInfo, correct_list_fields
 from .match import (
     AlbumMatch,
+    Candidates,
     Match,
     Proposal,
     Recommendation,
@@ -36,6 +37,7 @@ def __getattr__(name: str) -> Any:
 __all__ = [
     "AlbumInfo",
     "AlbumMatch",
+    "Candidates",
     "Distance",
     "Info",
     "Match",

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -4,10 +4,11 @@ releases and tracks.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import IntEnum
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypeVar, overload
 
 import lap
 import numpy as np
@@ -17,7 +18,7 @@ from beets import config, logging, metadata_plugins, plugins
 from .distance import VA_ARTISTS, distance, track_distance
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable
 
     from beets.autotag import Source
     from beets.library import Album, Item
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 
     JSONDict = dict[str, Any]
     AnyMatch = TypeVar("AnyMatch", "TrackMatch", "AlbumMatch")
-    Candidates = dict[Info.Identifier, AnyMatch]
+    CandidateMap = dict[Info.Identifier, AnyMatch]
 
 # Global logger.
 log = logging.getLogger("beets")
@@ -249,6 +250,41 @@ class Proposal(NamedTuple):
     recommendation: Recommendation
 
 
+class Candidates(Sequence[AlbumMatch | TrackMatch]):
+    """Mutable collection of candidate matches owned by one import task.
+
+    Manual search and ID lookups update this instance in place so the task
+    keeps a stable candidate collection across interactive choices.
+    """
+
+    def __init__(
+        self,
+        matches: Sequence[AlbumMatch | TrackMatch] | None = None,
+        recommendation: Recommendation = Recommendation.none,
+    ) -> None:
+        self._matches: list[AlbumMatch | TrackMatch] = list(matches or ())
+        self.recommendation = recommendation
+
+    def replace(self, proposal: Proposal) -> None:
+        """Replace matches and recommendation while keeping this instance."""
+        self._matches = list(proposal.candidates)
+        self.recommendation = proposal.recommendation
+
+    def __len__(self) -> int:
+        return len(self._matches)
+
+    @overload
+    def __getitem__(self, index: int) -> AlbumMatch | TrackMatch: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[AlbumMatch | TrackMatch]: ...
+
+    def __getitem__(
+        self, index: int | slice
+    ) -> AlbumMatch | TrackMatch | list[AlbumMatch | TrackMatch]:
+        return self._matches[index]
+
+
 def match_by_id(album_id: str | None, consensus: bool) -> Iterable[AlbumInfo]:
     """Return album candidates for the given album id.
 
@@ -329,7 +365,7 @@ def _sort_candidates(candidates: Iterable[AnyMatch]) -> Sequence[AnyMatch]:
 
 
 def _add_candidate(
-    source: Source, results: Candidates[AlbumMatch], info: AlbumInfo
+    source: Source, results: CandidateMap[AlbumMatch], info: AlbumInfo
 ) -> None:
     """Given a candidate AlbumInfo object, attempt to add the candidate
     to the output dictionary of AlbumMatch objects. This involves
@@ -404,7 +440,7 @@ def tag_album(
 
     # The output result, keys are (data_source, album_id) pairs, values are
     # AlbumMatch objects.
-    candidates: Candidates[AlbumMatch] = {}
+    candidates: CandidateMap[AlbumMatch] = {}
 
     # Search by explicit ID.
     if search_ids:
@@ -466,7 +502,7 @@ def tag_item(
     """
     # Holds candidates found so far: keys are (data_source, track_id) pairs,
     # values TrackMatch objects
-    candidates: Candidates[TrackMatch] = {}
+    candidates: CandidateMap[TrackMatch] = {}
     rec: Recommendation | None = None
 
     item = source.items[0]

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -24,7 +24,7 @@ from .actions import Action, DuplicateAction
 from .state import ImportState
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable, Mapping, Sequence
 
     from beets.autotag import Recommendation, TrackMatch
 

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, AnyStr
 import mediafile
 
 from beets import config, library, plugins, util
-from beets.autotag import AlbumMatch, Source, tag_album, tag_item
+from beets.autotag import AlbumMatch, Candidates, Source, tag_album, tag_item
 from beets.dbcore.query import PathQuery
 from beets.util import extension
 from beets.util.extension import remux_mpeglayer3_wav
@@ -23,7 +23,7 @@ from .actions import Action, DuplicateAction
 from .state import ImportState
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, Sequence
+    from collections.abc import Iterable, Mapping
 
     from beets.autotag import Recommendation, TrackMatch
 
@@ -240,8 +240,7 @@ class ImportTask(BaseImportTask):
     album: library.Album
 
     # Keep track of the current task item
-    candidates: Sequence[AlbumMatch | TrackMatch] | None = None
-    rec: Recommendation | None = None
+    candidates: Candidates
     duplicate_action: DuplicateAction | None = None
 
     # Set by `apply_upgrade` when `duplicate_action` is UPGRADE; consumed
@@ -254,6 +253,10 @@ class ImportTask(BaseImportTask):
     def source(self) -> Source:
         return Source.from_items(self.items)
 
+    @property
+    def rec(self) -> Recommendation:
+        return self.candidates.recommendation
+
     def __init__(
         self,
         toppath: util.PathBytes | None,
@@ -262,6 +265,7 @@ class ImportTask(BaseImportTask):
     ) -> None:
         super().__init__(toppath, paths, items)
         self.is_album = True
+        self.candidates = Candidates()
 
     def set_choice(self, choice: Action | AlbumMatch | TrackMatch) -> None:
         """Given an AlbumMatch or TrackMatch object or an action constant,
@@ -555,9 +559,7 @@ class ImportTask(BaseImportTask):
         If User-specified ``search_ids`` list is not empty, the lookup is
         restricted to only those IDs.
         """
-        self.candidates, self.rec = tag_album(
-            self.source, search_ids=search_ids
-        )
+        self.candidates.replace(tag_album(self.source, search_ids=search_ids))
 
     def find_duplicates(self, lib: library.Library) -> list[library.Album]:
         """Return a list of albums from `lib` with the same artist and
@@ -893,7 +895,7 @@ class SingletonImportTask(ImportTask):
             plugins.send("item_imported", lib=lib, item=item)
 
     def lookup_candidates(self, search_ids: list[str]) -> None:
-        self.candidates, self.rec = tag_item(self.source, search_ids=search_ids)
+        self.candidates.replace(tag_item(self.source, search_ids=search_ids))
 
     def find_duplicates(self, lib: library.Library) -> list[library.Item]:  # type: ignore[override] # Need splitting Singleton and Album tasks into separate classes
         """Return a list of items from `lib` that have the same artist

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -23,7 +23,7 @@ from .display import show_change, show_item_change
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from beets.autotag import Proposal, Source
+    from beets.autotag import Source
     from beets.importer import ImportSession, ImportTask
     from beets.library import AlbumOrItem, Item
     from beets.util import PathBytes
@@ -65,10 +65,7 @@ class TerminalImportSession(importer.ImportSession):
             )
 
         # Take immediate action if appropriate.
-        # TODO: introduce beets.autotag.Candidates to remove these assertions
-        assert task.rec is not None
-        assert task.candidates is not None
-        action = _summary_judgment(task.rec)
+        action = _summary_judgment(task.candidates.recommendation)
         if action == importer.Action.APPLY:
             match = task.candidates[0]
             # TODO: introduce AlbumImportTask to remove this assertion
@@ -86,9 +83,8 @@ class TerminalImportSession(importer.ImportSession):
             # `PromptChoice`.
             choices = self._get_choices(task)
             choice = choose_candidate(
-                # TODO: introduce AlbumImportTask to remove this ignore
-                task.candidates,  # type: ignore[arg-type]
-                task.rec,
+                task.candidates,
+                task.candidates.recommendation,
                 task.source,
                 choices=choices,
             )
@@ -124,10 +120,7 @@ class TerminalImportSession(importer.ImportSession):
         ui.print_(displayable_path(task.item.path))
 
         # Take immediate action if appropriate.
-        # TODO: introduce beets.autotag.Candidates to remove these assertions
-        assert task.rec is not None
-        assert task.candidates is not None
-        action = _summary_judgment(task.rec)
+        action = _summary_judgment(task.candidates.recommendation)
         if action == importer.Action.APPLY:
             match = task.candidates[0]
             # TODO: introduce AlbumImportTask to remove this assertion
@@ -141,9 +134,8 @@ class TerminalImportSession(importer.ImportSession):
             # Ask for a choice.
             choices = self._get_choices(task)
             choice = choose_candidate(
-                # TODO: introduce AlbumImportTask to remove this ignore
-                task.candidates,  # type: ignore[arg-type]
-                task.rec,
+                task.candidates,
+                task.candidates.recommendation,
                 task.source,
                 choices=choices,
             )
@@ -250,11 +242,8 @@ class TerminalImportSession(importer.ImportSession):
                 ),
             ]
         choices += [
-            # TODO: introduce beets.autotag.Candidates to remove these ignores
-            #  context: Candidates is a Sequence which will be updated in place
-            #  by manual_search and manual_id, with return types as None.
-            PromptChoice("e", "Enter search", manual_search),  # type: ignore[arg-type]
-            PromptChoice("i", "enter Id", manual_id),  # type: ignore[arg-type]
+            PromptChoice("e", "Enter search", manual_search),
+            PromptChoice("i", "enter Id", manual_id),
             PromptChoice("b", "aBort", abort_action),
         ]
 
@@ -504,8 +493,8 @@ def choose_candidate(
             return choice_actions[sel]
 
 
-def manual_search(session: ImportSession, task: ImportTask) -> Proposal:
-    """Get a new `Proposal` using manual search criteria.
+def manual_search(session: ImportSession, task: ImportTask) -> None:
+    """Update the task's candidates using manual search criteria.
 
     Input either an artist and album (for full albums) or artist and
     track name (for singletons) for manual search.
@@ -514,11 +503,11 @@ def manual_search(session: ImportSession, task: ImportTask) -> Proposal:
     name = ui.input_(f"{task.source.type.capitalize()}:").strip()
 
     method = tag_item if isinstance(task, SingletonImportTask) else tag_album
-    return method(task.source, artist, name)
+    task.candidates.replace(method(task.source, artist, name))
 
 
-def manual_id(session: ImportSession, task: ImportTask) -> Proposal:
-    """Get a new `Proposal` using a manually-entered ID.
+def manual_id(session: ImportSession, task: ImportTask) -> None:
+    """Update the task's candidates using a manually-entered ID.
 
     Input an ID, either for an album ("release") or a track ("recording").
     """
@@ -526,7 +515,7 @@ def manual_id(session: ImportSession, task: ImportTask) -> Proposal:
     search_id = ui.input_(prompt).strip()
 
     method = tag_item if isinstance(task, SingletonImportTask) else tag_album
-    return method(task.source, search_ids=search_id.split())
+    task.candidates.replace(method(task.source, search_ids=search_id.split()))
 
 
 def abort_action(session: ImportSession, task: ImportTask) -> None:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -93,6 +93,9 @@ Bug fixes
 - :doc:`plugins/tidal`: Pass the converted track duration as ``length`` so it
   contributes to the autotagging track-length distance instead of being silently
   stored as a ``duration`` flexible attribute.
+- Interactive import again applies results from ``enter Id`` and ``Enter
+  search``. Manual lookups now update the task's candidate collection in place,
+  so the new matches replace the previous list instead of being discarded.
 
 ..
     For plugin developers

--- a/test/autotag/test_match.py
+++ b/test/autotag/test_match.py
@@ -194,3 +194,36 @@ class TestTagMultipleDataSources:
         proposal = tag_item(source)
 
         self.check_proposal(proposal)
+
+
+class TestCandidates:
+    def test_replace_keeps_identity_and_updates_contents(self):
+        from beets.autotag import (
+            AlbumMatch,
+            Candidates,
+            Distance,
+            Proposal,
+            Recommendation,
+            TrackInfo,
+        )
+        from beets.autotag.hooks import AlbumInfo
+
+        track = TrackInfo(title="t", track_id="tid", index=1)
+        info = AlbumInfo(
+            album="a",
+            album_id="aid",
+            artist="ar",
+            artist_id="arid",
+            tracks=[track],
+        )
+        match = AlbumMatch(Distance(), info, {})
+        candidates = Candidates()
+        candidates_id = id(candidates)
+
+        candidates.replace(Proposal([match], Recommendation.strong))
+
+        assert id(candidates) == candidates_id
+        assert list(candidates) == [match]
+        assert candidates.recommendation == Recommendation.strong
+        assert len(candidates) == 1
+        assert candidates[0] is match

--- a/test/ui/commands/test_import.py
+++ b/test/ui/commands/test_import.py
@@ -4,14 +4,28 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from beets import config, library
-from beets.autotag import AlbumInfo, AlbumMatch, Source, TrackInfo, distance
+from beets import config, importer, library
+from beets.autotag import (
+    AlbumInfo,
+    AlbumMatch,
+    Distance,
+    Proposal,
+    Recommendation,
+    Source,
+    TrackInfo,
+    TrackMatch,
+    distance,
+)
 from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 from beets.ui.commands.import_ import paths_from_logfile
 from beets.ui.commands.import_.display import show_change
-from beets.ui.commands.import_.session import summarize_items
+from beets.ui.commands.import_.session import (
+    TerminalImportSession,
+    summarize_items,
+)
+from beets.util import PromptChoice
 
 
 class ImportTest(BeetsTestCase):
@@ -188,3 +202,128 @@ class SummarizeItemsTest(unittest.TestCase):
 
         summary = summarize_items([self.item, i2, i2], False)
         assert summary == "3 items, G 2, F 1, 4kbps, 32:42, 2.9 KiB"
+
+
+class ManualLookupCandidatesTest(IOMixin, BeetsTestCase):
+    """Manual search/ID must mutate and reuse the task's Candidates object."""
+
+    def _album_match(self, item: library.Item, album: str) -> AlbumMatch:
+        track = TrackInfo(title=item.title, track_id="tid", index=1)
+        info = AlbumInfo(
+            album=album,
+            album_id=f"id-{album}",
+            artist=item.artist,
+            artist_id="aid",
+            tracks=[track],
+            data_source="test",
+        )
+        return AlbumMatch(Distance(), info, {item: track})
+
+    def _track_match(self, item: library.Item, title: str) -> TrackMatch:
+        info = TrackInfo(
+            title=title,
+            track_id=f"id-{title}",
+            artist=item.artist,
+            artist_id="aid",
+            data_source="test",
+        )
+        return TrackMatch(Distance(), info, item)
+
+    def test_choose_match_reuses_candidates_on_manual_id(self) -> None:
+        item = _common.item()
+        task = importer.ImportTask(b"/top", [b"/path"], [item])
+        old_match = self._album_match(item, "Old Album")
+        new_match = self._album_match(item, "Manual Album")
+        task.candidates.replace(Proposal([old_match], Recommendation.none))
+        candidates_id = id(task.candidates)
+
+        session = TerminalImportSession(self.lib, None, None, [])
+
+        def manual_id_callback(_s, t):
+            t.candidates.replace(Proposal([new_match], Recommendation.strong))
+            return
+
+        enter_id = PromptChoice("i", "enter Id", manual_id_callback)
+        calls = {"n": 0}
+
+        def fake_choose(candidates, rec, source, choices=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return enter_id
+            assert candidates is task.candidates
+            assert candidates[0].info.album == "Manual Album"
+            assert rec == Recommendation.strong
+            return candidates[0]
+
+        with patch(
+            "beets.ui.commands.import_.session.choose_candidate", fake_choose
+        ):
+            result = session.choose_match(task)
+
+        assert result is new_match
+        assert id(task.candidates) == candidates_id
+        assert list(task.candidates) == [new_match]
+        assert task.candidates.recommendation == Recommendation.strong
+
+    def test_choose_item_reuses_candidates_on_manual_id(self) -> None:
+        item = _common.item()
+        task = importer.SingletonImportTask(b"/top", item)
+        old_match = self._track_match(item, "Old Title")
+        new_match = self._track_match(item, "Manual Title")
+        task.candidates.replace(Proposal([old_match], Recommendation.none))
+        candidates_id = id(task.candidates)
+
+        session = TerminalImportSession(self.lib, None, None, [])
+
+        def manual_id_callback(_s, t):
+            t.candidates.replace(Proposal([new_match], Recommendation.strong))
+            return
+
+        enter_id = PromptChoice("i", "enter Id", manual_id_callback)
+        calls = {"n": 0}
+
+        def fake_choose(candidates, rec, source, choices=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return enter_id
+            assert candidates is task.candidates
+            assert candidates[0].info.title == "Manual Title"
+            assert rec == Recommendation.strong
+            return candidates[0]
+
+        with patch(
+            "beets.ui.commands.import_.session.choose_candidate", fake_choose
+        ):
+            result = session.choose_item(task)
+
+        assert result is new_match
+        assert id(task.candidates) == candidates_id
+        assert list(task.candidates) == [new_match]
+        assert task.candidates.recommendation == Recommendation.strong
+
+    def test_manual_id_updates_task_candidates_in_place(self) -> None:
+        from beets.ui.commands.import_.session import manual_id
+
+        item = _common.item()
+        task = importer.ImportTask(b"/top", [b"/path"], [item])
+        old_match = self._album_match(item, "Old Album")
+        new_match = self._album_match(item, "Manual Album")
+        task.candidates.replace(Proposal([old_match], Recommendation.none))
+        candidates_id = id(task.candidates)
+        session = TerminalImportSession(self.lib, None, None, [])
+
+        with (
+            patch(
+                "beets.ui.commands.import_.session.ui.input_",
+                return_value="album-id",
+            ),
+            patch(
+                "beets.ui.commands.import_.session.tag_album",
+                return_value=Proposal([new_match], Recommendation.strong),
+            ),
+        ):
+            manual_id(session, task)
+
+        assert id(task.candidates) == candidates_id
+        assert list(task.candidates) == [new_match]
+        assert task.candidates.recommendation == Recommendation.strong


### PR DESCRIPTION
﻿Regression from #6925: typing cleanup dropped the handler that replaced task candidates after Enter Id / Enter search, so the importer kept showing the original candidate list.

This lands the #6685 acceptance criterion that manual search / manual ID reuse and mutate the same candidate collection (`task.candidates`) in place, returning `None` to match the `PromptChoice` callback contract.

Addresses #6685 (manual search/ID portion).

Replaces #6988 (closed when the fork was recreated).

### Reproduction

1. Import an album with weak auto-matches.
2. Choose Enter Id and paste a MusicBrainz release ID.
3. Logs show a successful fetch (`Candidate: ...`, `Success. Distance: ...`).
4. **Bug:** prompt still lists the original candidates instead of the manual lookup result.

### Approach

- Import tasks own a mutable `Candidates` collection.
- `manual_id` / `manual_search` update that collection in place and return `None`.

### Checklist

- [x] ~~Documentation~~
- [x] Changelog
- [x] Tests
