### PR TITLE
docs: fix broken links and expand linkcheck_ignore

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -424,7 +424,7 @@ contributor.
 
 .. _test: https://github.com/beetbox/beets/tree/master/test
 
-.. _test-query: https://github.com/beetbox/beets/blob/master/test/test_query.py
+.. _test-query: https://github.com/beetbox/beets/blob/master/test/dbcore/test_query.py
 
 .. _unittest: https://docs.python.org/3/library/unittest.html
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -133,6 +133,9 @@ Other changes
 
 - :doc:`plugins/bpd`: Replace the bundled Bluelet scheduler with Python's
   standard ``asyncio`` event loop.
+- Docs: fix broken link to ``test/dbcore/test_query.py`` in
+  ``CONTRIBUTING.rst``; add crawler-blocking and unreachable sites to
+  ``linkcheck_ignore`` in ``docs/conf.py``.
 
 2.13.1 (July 29, 2026)
 ----------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,6 +83,12 @@ linkcheck_ignore = [
     r"https://www.gnu.org.*",  # sometimes unreachable
     r"https://www.nongnu.org.*",  # sometimes unreachable
     r"https://web.archive.org.*",  # sometimes unreachable
+    r"https://www.sonos.com.*",  # blocks requests
+    r"https://stackoverflow.com.*",  # blocks requests
+    r"https://superuser.com.*",  # blocks requests
+    r"https://support.discogs.com.*",  # blocks requests
+    r"https://forge\.kanis\.fr.*",  # SSL cert issues
+    r"https://id3\.org.*",  # intermittent server errors
 ]
 
 # Options for HTML output


### PR DESCRIPTION
## Summary

- Fix 404 link to `test/test_query.py` in `CONTRIBUTING.rst` — file moved to `test/dbcore/test_query.py`
- Add crawler-blocking and unreachable sites to `linkcheck_ignore` in `docs/conf.py`:
  - `sonos.com`, `stackoverflow.com`, `superuser.com`, `support.discogs.com` — return 403 to bots
  - `forge.kanis.fr` — SSL certificate mismatch
  - `id3.org` — intermittent 500 errors

These failures have been causing the docs linkcheck CI job to fail on every run, unrelated to any code changes.

## Test plan

- [ ] Docs linkcheck CI passes after this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbXC9acP8vTyQr59J5UbCV