### PR TITLE
lyrics: support 3-decimal millisecond timestamps in LRC parsing

### DIFF
--- a/beets/util/lyrics.py
+++ b/beets/util/lyrics.py
@@ -27,8 +27,8 @@ class Lyrics:
 
     ORIGINAL_PAT = re.compile(r"[^\n]+ / ")
     TRANSLATION_PAT = re.compile(r" / [^\n]+")
-    LINE_PARTS_PAT = re.compile(r"^(\[\d\d:\d\d\.\d\d\]|) *(.*)$")
-    LRC_TIMESTAMP_PAT = re.compile(r"\[(\d{2}):(\d{2})\.(\d{2})\]")
+    LINE_PARTS_PAT = re.compile(r"^(\[\d\d:\d\d\.\d{2,3}\]|) *(.*)$")
+    LRC_TIMESTAMP_PAT = re.compile(r"\[(\d{2}):(\d{2})\.(\d{2,3})\]")
 
     text: str
     backend: str | None = None
@@ -148,8 +148,9 @@ class Lyrics:
                 continue
             ts_m = self.LRC_TIMESTAMP_PAT.match(ts)
             if ts_m:
-                m, s, cs = map(int, ts_m.groups())
-                ms = (m * 60 + s) * 1000 + cs * 10
+                m, s = map(int, ts_m.groups()[:2])
+                frac = ts_m.group(3)
+                ms = (m * 60 + s) * 1000 + int(frac.ljust(3, "0"))
                 result.append((text, ms))
         return result
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,9 +13,13 @@ Unreleased
     New features
     ~~~~~~~~~~~~
 
-..
-    Bug fixes
-    ~~~~~~~~~
+Bug fixes
+~~~~~~~~~
+
+- :doc:`plugins/lyrics`: Support 3-decimal millisecond timestamps (e.g.
+  ``[mm:ss.xxx]``) in LRC parsing, fixing an issue where synced lyrics with
+  millisecond precision were erroneously rejected and fell back to plain lyrics.
+  :bug:`7001`
 
 ..
     For plugin developers

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -640,6 +640,15 @@ class TestLRCLibLyrics(LyricsBackendTest):
             pytest.param([], None, id="handle non-matching lyrics"),
             pytest.param([lyrics_match()], SYNCED, id="synced when available"),
             pytest.param(
+                [
+                    lyrics_match(
+                        syncedLyrics="[00:01.234] 3-decimal synced lyrics"
+                    )
+                ],
+                "[00:01.234] 3-decimal synced lyrics",
+                id="synced with 3-decimal millisecond timestamp",
+            ),
+            pytest.param(
                 [lyrics_match(duration=1)], None, id="none: duration too short"
             ),
             pytest.param(

--- a/test/util/test_lyrics.py
+++ b/test/util/test_lyrics.py
@@ -52,3 +52,32 @@ class TestLyrics:
             "FR" if langdetect_available else None
         )
         assert not lyrics.instrumental
+
+    def test_timestamp_precision_and_sylt(self):
+        text = textwrap.dedent("""
+        [00:00.05] Centisecond line
+        [00:01.50] Two decimals
+        [00:02.123] Three decimals
+        [01:00.005] Five milliseconds
+        """).strip()
+        lyrics = Lyrics(text)
+
+        assert lyrics.synced
+        assert lyrics.timestamps == [
+            "[00:00.05]",
+            "[00:01.50]",
+            "[00:02.123]",
+            "[01:00.005]",
+        ]
+        assert lyrics.text_lines == [
+            "Centisecond line",
+            "Two decimals",
+            "Three decimals",
+            "Five milliseconds",
+        ]
+        assert lyrics.sylt == [
+            ("Centisecond line", 50),
+            ("Two decimals", 1500),
+            ("Three decimals", 2123),
+            ("Five milliseconds", 60005),
+        ]


### PR DESCRIPTION
## Description

LRCLIB commonly returns LRC timestamps with 3 decimal places (`[mm:ss.xxx]`). `LINE_PARTS_PAT` and `LRC_TIMESTAMP_PAT` strictly expected two digits (`\.\d\d`), causing `verify_synced_lyrics` to fail when the final line of a song has millisecond precision and silently fall back to `plainLyrics`.

Additionally, interior 3-decimal lines had timestamps dropped from ID3 `SYLT` frames and leaked raw bracketed tags into plain text extraction.

- Update regexes to accept `\.\d{2,3}`
- Parse both 2-digit (cs) and 3-digit (ms) fractions in `Lyrics.sylt`
- Add unit tests and changelog entry

## To Do

- [x] ~Documentation~
- [x] Changelog
- [x] Tests