### PR TITLE
Add `-l`/`--limit` option to all commands that accept QUERY

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -612,6 +612,33 @@ class CommonOptionsParser(optparse.OptionParser):
         )
         self.add_option(opt)
 
+    def _set_limit(
+        self,
+        option: optparse.Option,
+        opt_str: str,
+        value: int,
+        parser: optparse.OptionParser,
+    ) -> None:
+        """Validate and store a maximum query result count."""
+        if value < 0:
+            raise UserError(
+                f"{opt_str} argument must be a non-negative integer"
+            )
+        assert option.dest is not None
+        setattr(parser.values, option.dest, value)
+
+    def add_limit_option(
+        self, flags: Sequence[str] = ("-l", "--limit")
+    ) -> None:
+        """Add an option to cap the number of matched query results."""
+        self.add_option(
+            *flags,
+            type="int",
+            action="callback",
+            callback=self._set_limit,
+            help="limit query results",
+        )
+
     def add_all_common_options(self) -> None:
         """Add album, path and format options."""
         self.add_album_option()

--- a/beets/ui/commands/list.py
+++ b/beets/ui/commands/list.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from beets import ui
-from beets.exceptions import UserError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -33,8 +32,6 @@ def list_items(
 
 
 def list_func(lib: Library, opts: ListCLIOpts, args: list[str]) -> None:
-    if opts.limit is not None and opts.limit < 0:
-        raise UserError("-l / --limit argument must be a non-negative integer")
     list_items(lib, args, opts)
 
 
@@ -44,7 +41,5 @@ list_cmd.parser.set_usage(
     + "\nExample: %prog -f '$album: $title' artist:beatles"
 )
 list_cmd.parser.add_all_common_options()
-list_cmd.parser.add_option(
-    "-l", "--limit", type=int, help="limit query results"
-)
+list_cmd.parser.add_limit_option()
 list_cmd.func = list_func

--- a/beets/ui/commands/modify.py
+++ b/beets/ui/commands/modify.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 class ModifyCLIOpts(Protocol):
     album: bool
     inherit: bool
+    limit: int | None
     move: bool | None
     write: bool | None
     yes: bool | None
@@ -139,15 +140,21 @@ def modify_objects(
 
 
 def modify_items(
-    lib: Library, query: Sequence[str], **kwargs: Unpack[ModifyParams]
+    lib: Library,
+    query: Sequence[str],
+    limit: int | None,
+    **kwargs: Unpack[ModifyParams],
 ) -> None:
-    modify_objects(Item, list(lib.items(query)), lib, **kwargs)
+    modify_objects(Item, list(lib.items(query, limit=limit)), lib, **kwargs)
 
 
 def modify_albums(
-    lib: Library, query: Sequence[str], **kwargs: Unpack[ModifyParams]
+    lib: Library,
+    query: Sequence[str],
+    limit: int | None,
+    **kwargs: Unpack[ModifyParams],
 ) -> None:
-    modify_objects(Album, list(lib.albums(query)), lib, **kwargs)
+    modify_objects(Album, list(lib.albums(query, limit=limit)), lib, **kwargs)
 
 
 def print_and_modify(
@@ -204,6 +211,7 @@ def modify_func(lib: Library, opts: ModifyCLIOpts, args: list[str]) -> None:
     method(
         lib,
         query,
+        opts.limit,
         mods=mods,
         dels=dels,
         write=ui.should_write(opts.write),
@@ -257,4 +265,5 @@ modify_cmd.parser.add_option(
     default=True,
     help="when modifying albums, don't also change item data",
 )
+modify_cmd.parser.add_limit_option()
 modify_cmd.func = modify_func

--- a/beets/ui/commands/move.py
+++ b/beets/ui/commands/move.py
@@ -24,6 +24,7 @@ class MoveCLIOpts(Protocol):
     copy: bool
     dest: str | None
     export: bool
+    limit: int | None
     pretend: bool
     timid: bool
 
@@ -152,7 +153,7 @@ def move_items(
     def get_paths(objs: Iterable[Item]) -> list[tuple[bytes, bytes]]:
         return [(obj.path, obj.destination(basedir=dest)) for obj in objs]
 
-    objs = list(lib.items(query))
+    objs = list(lib.items(query, limit=opts.limit))
     move_objects(objs, isitemmoved, "item", get_paths, dest=dest, opts=opts)
 
 
@@ -166,7 +167,7 @@ def move_albums(
             for item in obj.items()
         ]
 
-    objs = list(lib.albums(query))
+    objs = list(lib.albums(query, limit=opts.limit))
     move_objects(objs, isalbummoved, "album", get_paths, dest=dest, opts=opts)
 
 
@@ -214,4 +215,5 @@ move_cmd.parser.add_option(
     help="copy without changing the database path",
 )
 move_cmd.parser.add_album_option()
+move_cmd.parser.add_limit_option()
 move_cmd.func = move_func

--- a/beets/ui/commands/remove.py
+++ b/beets/ui/commands/remove.py
@@ -18,6 +18,7 @@ class RemoveCLIOpts(Protocol):
     album: bool
     delete: bool
     force: bool
+    limit: int | None
 
 
 def remove_objects(
@@ -84,7 +85,7 @@ def remove_items(
     lib: Library, query: Sequence[str], opts: RemoveCLIOpts
 ) -> None:
     """Remove items matching query from lib."""
-    items = list(lib.items(query))
+    items = list(lib.items(query, limit=opts.limit))
     album_str = ""
 
     remove_objects(items, fmt_item, len(items), album_str, lib, opts=opts)
@@ -94,7 +95,7 @@ def remove_albums(
     lib: Library, query: Sequence[str], opts: RemoveCLIOpts
 ) -> None:
     """Remove albums matching query from lib."""
-    albums = list(lib.albums(query))
+    albums = list(lib.albums(query, limit=opts.limit))
     items = [i for a in albums for i in a.items()]
     album_str = f" and {len(albums)} album{'s' if len(albums) > 1 else ''}"
 
@@ -124,4 +125,5 @@ remove_cmd.parser.add_option(
     help="do not ask when removing items",
 )
 remove_cmd.parser.add_album_option()
+remove_cmd.parser.add_limit_option()
 remove_cmd.func = remove_func

--- a/beets/ui/commands/stats.py
+++ b/beets/ui/commands/stats.py
@@ -21,11 +21,14 @@ log = logging.getLogger("beets")
 
 class StatsCLIOpts(Protocol):
     exact: bool
+    limit: int | None
 
 
-def show_stats(lib: Library, query: Sequence[str], exact: bool) -> None:
+def show_stats(
+    lib: Library, query: Sequence[str], exact: bool, limit: int | None
+) -> None:
     """Shows some statistics about the matched items."""
-    items = lib.items(query)
+    items = lib.items(query, limit=limit)
 
     total_size = 0
     total_time = 0.0
@@ -63,7 +66,7 @@ Album artists: {len(album_artists)}""")
 
 
 def stats_func(lib: Library, opts: StatsCLIOpts, args: list[str]) -> None:
-    show_stats(lib, args, opts.exact)
+    show_stats(lib, args, opts.exact, opts.limit)
 
 
 stats_cmd = ui.Subcommand(
@@ -76,4 +79,5 @@ stats_cmd.parser.add_option(
     default=False,
     help="exact size and time",
 )
+stats_cmd.parser.add_limit_option()
 stats_cmd.func = stats_func

--- a/beets/ui/commands/update.py
+++ b/beets/ui/commands/update.py
@@ -24,6 +24,7 @@ class UpdateCLIOpts(Protocol):
     album: bool
     exclude_fields: list[str] | None
     fields: list[str] | None
+    limit: int | None
     move: bool | None
     pretend: bool
 
@@ -173,9 +174,11 @@ def update_func(lib: Library, opts: UpdateCLIOpts, args: list[str]) -> None:
         if not ui.input_yn("Are you sure you want to continue (y/n)?", True):
             return
     if opts.album:
-        items = [i for a in lib.albums(args) for i in a.items()]
+        items = [
+            i for a in lib.albums(args, limit=opts.limit) for i in a.items()
+        ]
     else:
-        items = list(lib.items(args))
+        items = list(lib.items(args, limit=opts.limit))
     update_items(
         lib,
         items,
@@ -228,4 +231,5 @@ update_cmd.parser.add_option(
     dest="exclude_fields",
     help="list of fields to exclude from updates",
 )
+update_cmd.parser.add_limit_option()
 update_cmd.func = update_func

--- a/beets/ui/commands/write.py
+++ b/beets/ui/commands/write.py
@@ -21,16 +21,21 @@ log = logging.getLogger("beets")
 
 class WriteCLIOpts(Protocol):
     force: bool
+    limit: int | None
     pretend: bool
 
 
 def write_items(
-    lib: Library, query: Sequence[str], pretend: bool, force: bool
+    lib: Library,
+    query: Sequence[str],
+    pretend: bool,
+    force: bool,
+    limit: int | None,
 ) -> None:
     """Write tag information from the database to the respective files
     in the filesystem.
     """
-    items = lib.items(query)
+    items = lib.items(query, limit=limit)
 
     if not items:
         raise UserError("No matching items to write.")
@@ -59,7 +64,7 @@ def write_items(
 
 
 def write_func(lib: Library, opts: WriteCLIOpts, args: list[str]) -> None:
-    write_items(lib, args, opts.pretend, opts.force)
+    write_items(lib, args, opts.pretend, opts.force, opts.limit)
 
 
 write_cmd = ui.Subcommand("write", help="write tag information to files")
@@ -77,4 +82,5 @@ write_cmd.parser.add_option(
     default=False,
     help="write tags even if the existing tags match the database",
 )
+write_cmd.parser.add_limit_option()
 write_cmd.func = write_func

--- a/beetsplug/_utils/art.py
+++ b/beetsplug/_utils/art.py
@@ -212,9 +212,12 @@ def clear_item(item: Item, log: Logger) -> None:
 
 
 def clear(
-    log: Logger, lib: Library, query: str | Sequence[str] | Query | None = None
+    log: Logger,
+    lib: Library,
+    query: str | Sequence[str] | Query | None = None,
+    limit: int | None = None,
 ) -> None:
-    items = lib.items(query)
+    items = lib.items(query, limit=limit)
     log.info("Clearing album art from {} items", len(items))
     for item in items:
         clear_item(item, log)

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 class ABSubmitCLIOpts(Protocol):
     force_refetch: bool
+    limit: int | None
     pretend_fetch: bool
 
 
@@ -135,6 +136,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
                 " processed"
             ),
         )
+        cmd.parser.add_limit_option()
         cmd.func = self.command
         return [cmd]
 
@@ -148,7 +150,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
                 "option."
             )
         # Get items from arguments
-        items = lib.items(args)
+        items = lib.items(args, limit=opts.limit)
         self.opts = opts
         util.par_map(self.analyze_submit, items)
 

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 class AcousticBrainzCLIOpts(Protocol):
     force_refetch: bool
+    limit: int | None
 
 
 LEVELS = ["/low-level", "/high-level"]
@@ -121,13 +122,14 @@ class AcousticPlugin(plugins.BeetsPlugin):
         def func(
             lib: Library, opts: AcousticBrainzCLIOpts, args: list[str]
         ) -> None:
-            items = lib.items(args)
+            items = lib.items(args, limit=opts.limit)
             self._fetch_info(
                 items,
                 ui.should_write(),
                 opts.force_refetch or self.config["force"].get(bool),
             )
 
+        cmd.parser.add_limit_option()
         cmd.func = func
         return [cmd]
 

--- a/beetsplug/autobpm.py
+++ b/beetsplug/autobpm.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 class AutoBPMCLIOpts(Protocol):
     force: bool
+    limit: int | None
     quiet: bool
 
 
@@ -66,6 +67,7 @@ class AutoBPMPlugin(BeetsPlugin):
             default=False,
             help="Suppress message when item already has BPM",
         )
+        cmd.parser.add_limit_option()
         cmd.func = self.command
         return [cmd]
 
@@ -75,7 +77,7 @@ class AutoBPMPlugin(BeetsPlugin):
         force = self.config["force"].get(bool) or opts.force
         quiet = self.config["quiet"].get(bool) or opts.quiet
         self.calculate_bpm(
-            list(lib.items(args)),
+            list(lib.items(args, limit=opts.limit)),
             write=should_write(),
             force=force,
             quiet=quiet,

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -27,6 +27,7 @@ ImportAction = Literal["abort", "skip", "continue"]
 
 
 class BadCLIOpts(Protocol):
+    limit: int | None
     verbose: bool
 
 
@@ -260,7 +261,7 @@ class BadFiles(BeetsPlugin):
 
     def command(self, lib: Library, opts: BadCLIOpts, args: list[str]) -> None:
         # Get items from arguments
-        items = lib.items(args)
+        items = lib.items(args, limit=opts.limit)
         self.verbose = opts.verbose
 
         def check_and_print(item: Item) -> None:
@@ -281,5 +282,6 @@ class BadFiles(BeetsPlugin):
             dest="verbose",
             help="view results for both the bad and uncorrupted files",
         )
+        bad_command.parser.add_limit_option()
         bad_command.func = self.command
         return [bad_command]

--- a/beetsplug/bareasc.py
+++ b/beetsplug/bareasc.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 class BareascCLIOpts(Protocol):
     album: bool
+    limit: int | None
 
 
 class BareascQuery(StringFieldQuery[str]):
@@ -73,6 +74,7 @@ class BareascPlugin(BeetsPlugin):
             + "\nExample: %prog -f '$album: $title' artist:beatles"
         )
         cmd.parser.add_all_common_options()
+        cmd.parser.add_limit_option()
         cmd.func = self.unidecode_list
         return [cmd]
 
@@ -83,10 +85,10 @@ class BareascPlugin(BeetsPlugin):
         album = opts.album
         # Copied from commands.py - list_items
         if album:
-            for album_obj in lib.albums(args):
+            for album_obj in lib.albums(args, limit=opts.limit):
                 bare = unidecode(str(album_obj))
                 print_(bare)
         else:
-            for item in lib.items(args):
+            for item in lib.items(args, limit=opts.limit):
                 bare = unidecode(str(item))
                 print_(bare)

--- a/beetsplug/bench.py
+++ b/beetsplug/bench.py
@@ -25,6 +25,7 @@ class BenchAunique(Protocol):
 class BenchMatch(Protocol):
     profile: bool
     id: str | None
+    limit: int | None
 
 
 def aunique_benchmark(
@@ -70,7 +71,9 @@ def match_benchmark(lib: Library, opts: BenchMatch, args: list[str]) -> None:
     id_ = opts.id or "9c5c043e-bc69-4edb-81a4-1aaf9c81e6dc"
 
     # Get an album from the library to use as the source for the match.
-    items: Sequence[Item] = i.items() if (i := lib.albums(args).get()) else []
+    items: Sequence[Item] = (
+        i.items() if (i := lib.albums(args, limit=opts.limit).get()) else []
+    )
 
     # Ensure fingerprinting is invoked (if enabled).
     plugins.send(
@@ -122,6 +125,7 @@ class BenchmarkPlugin(BeetsPlugin):
         match_bench_cmd.parser.add_option(
             "-i", "--id", default=None, help="album ID to match against"
         )
+        match_bench_cmd.parser.add_limit_option()
         match_bench_cmd.func = match_benchmark
 
         return [aunique_bench_cmd, match_bench_cmd]

--- a/beetsplug/bpm.py
+++ b/beetsplug/bpm.py
@@ -48,6 +48,7 @@ class BPMPlugin(BeetsPlugin):
             "bpm",
             help="determine bpm of a song by pressing a key to the rhythm",
         )
+        cmd.parser.add_limit_option()
         cmd.func = self.command
         return [cmd]
 
@@ -55,7 +56,7 @@ class BPMPlugin(BeetsPlugin):
         self, lib: Library, opts: optparse.Values, args: list[str]
     ) -> None:
         write = ui.should_write()
-        self.get_bpm(lib.items(args), write)
+        self.get_bpm(lib.items(args, limit=opts.limit), write)
 
     def get_bpm(self, items: Sequence[Item], write: bool = False) -> None:
         overwrite = self.config["overwrite"].get(bool)

--- a/beetsplug/bpsync.py
+++ b/beetsplug/bpsync.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 
 class BPSyncCLIOpts(Protocol):
+    limit: int | None
     move: bool | None
     pretend: bool
     write: bool | None
@@ -63,6 +64,7 @@ class BPSyncPlugin(BeetsPlugin):
             help="don't write updated metadata to files",
         )
         cmd.parser.add_format_option()
+        cmd.parser.add_limit_option()
         cmd.func = self.func
         return [cmd]
 
@@ -72,8 +74,8 @@ class BPSyncPlugin(BeetsPlugin):
         pretend = opts.pretend
         write = ui.should_write(opts.write)
 
-        self.singletons(lib, args, move, pretend, write)
-        self.albums(lib, args, move, pretend, write)
+        self.singletons(lib, args, move, pretend, write, opts.limit)
+        self.albums(lib, args, move, pretend, write, opts.limit)
 
     def singletons(
         self,
@@ -82,11 +84,12 @@ class BPSyncPlugin(BeetsPlugin):
         move: bool,
         pretend: bool,
         write: bool,
+        limit: int | None,
     ) -> None:
         """Retrieve and apply info from the autotagger for items matched by
         query.
         """
-        for item in lib.items([*query, "singleton:true"]):
+        for item in lib.items([*query, "singleton:true"], limit=limit):
             if not item.mb_trackid:
                 self._log.info(
                     "Skipping singleton with no mb_trackid: {}", item
@@ -146,12 +149,13 @@ class BPSyncPlugin(BeetsPlugin):
         move: bool,
         pretend: bool,
         write: bool,
+        limit: int | None,
     ) -> None:
         """Retrieve and apply info from the autotagger for albums matched by
         query and their items.
         """
         # Process matching albums.
-        for album in lib.albums(query):
+        for album in lib.albums(query, limit=limit):
             # Do we have a valid Beatport album?
             items = self.get_album_tracks(album)
             if not items:

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 class ChromaSearchCLIOpts(Protocol):
     count: int
     full: bool | None
+    limit: int | None
     search: str | None
     write: bool | None
 
@@ -283,8 +284,9 @@ class AcoustidPlugin(MetadataSourcePlugin):
                 apikey = config["acoustid"]["apikey"].as_str()
             except confuse.NotFoundError:
                 raise UserError("no Acoustid user API key provided")
-            submit_items(self._log, apikey, lib.items(args))
+            submit_items(self._log, apikey, lib.items(args, limit=opts.limit))
 
+        submit_cmd.parser.add_limit_option()
         submit_cmd.func = submit_cmd_func
 
         fingerprint_cmd = ui.Subcommand(
@@ -294,9 +296,10 @@ class AcoustidPlugin(MetadataSourcePlugin):
         def fingerprint_cmd_func(
             lib: Library, opts: optparse.Values, args: list[str]
         ) -> None:
-            for item in lib.items(args):
+            for item in lib.items(args, limit=opts.limit):
                 fingerprint_item(self._log, item, write=ui.should_write())
 
+        fingerprint_cmd.parser.add_limit_option()
         fingerprint_cmd.func = fingerprint_cmd_func
 
         return [submit_cmd, fingerprint_cmd, self.chromasearch_cmd()]
@@ -336,6 +339,7 @@ class AcoustidPlugin(MetadataSourcePlugin):
             action="store_true",
             help="Write computed fingerprints to files",
         )
+        cmd.parser.add_limit_option()
 
         def search_cmd_func(
             lib: Library, opts: ChromaSearchCLIOpts, args: list[str]
@@ -348,7 +352,7 @@ class AcoustidPlugin(MetadataSourcePlugin):
             target = (0, opts.search.encode("utf-8"))
             top = TopN(opts.count)
 
-            for item in lib.items(args):
+            for item in lib.items(args, limit=opts.limit):
                 fp = fingerprint_item(
                     self._log,
                     item,

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -40,6 +40,7 @@ _temp_files: list[bytes] = []
 class ConvertCLIOpts(Protocol):
     album: bool
     keep_new: bool
+    limit: int | None
     yes: bool | None
 
 
@@ -218,6 +219,7 @@ class ConvertPlugin(BeetsPlugin):
             ),
         )
         cmd.parser.add_album_option()
+        cmd.parser.add_limit_option(flags=("--limit",))
         cmd.func = self.convert_func
         return [cmd]
 
@@ -674,13 +676,13 @@ class ConvertPlugin(BeetsPlugin):
         pretend = self.pretend
 
         if opts.album:
-            albums = lib.albums(args)
+            albums = lib.albums(args, limit=opts.limit)
             items = [i for a in albums for i in a.items()]
             if not pretend:
                 for a in albums:
                     ui.print_(format(a, ""))
         else:
-            items = list(lib.items(args))
+            items = list(lib.items(args, limit=opts.limit))
             if not pretend:
                 for i in items:
                     ui.print_(format(i, ""))

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -49,9 +49,10 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         )
 
         def func(lib: Library, opts: optparse.Values, args: list[str]) -> None:
-            items = lib.items(args)
+            items = lib.items(args, limit=opts.limit)
             self.deezerupdate(list(items), ui.should_write())
 
+        deezer_update_cmd.parser.add_limit_option()
         deezer_update_cmd.func = func
 
         return [deezer_update_cmd]

--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -137,6 +137,7 @@ class DuplicatesPlugin(BeetsPlugin):
             help="remove items from library",
         )
         self._command.parser.add_all_common_options()
+        self._command.parser.add_limit_option()
 
     def commands(self) -> list[Subcommand]:
         def _dup(lib: Library, opts: optparse.Values, args: list[str]) -> None:
@@ -145,14 +146,14 @@ class DuplicatesPlugin(BeetsPlugin):
 
             if self.config["album"].get(bool):
                 self._run_command(
-                    lib.albums(args),
+                    lib.albums(args, limit=opts.limit),
                     keys or ["mb_albumid"],
                     "$albumartist - $album",
                     merge_func=self._merge_albums,
                 )
             else:
                 self._run_command(
-                    lib.items(args),
+                    lib.items(args, limit=opts.limit),
                     keys or ["mb_trackid", "mb_albumid"],
                     "$albumartist - $album - $title",
                     merge_func=self._merge_items,

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 class EmbedArtCLIOpts(Protocol):
     file: str | None
+    limit: int | None
     url: str | None
     yes: bool | None
 
@@ -33,10 +34,12 @@ class EmbedArtCLIOpts(Protocol):
 class ExtractArtCLIOpts(Protocol):
     associate: bool | None
     filename: str | None
+    limit: int | None
     outpath: str | None
 
 
 class ClearArtCLIOpts(Protocol):
+    limit: int | None
     yes: bool | None
 
 
@@ -133,7 +136,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                         f"image file {displayable_path(imagepath)} not found"
                     )
 
-                items = lib.items(args)
+                items = lib.items(args, limit=opts.limit)
 
                 # Confirm with user.
                 if not opts.yes and not _confirm(items, not opts.file):
@@ -169,7 +172,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                 except Exception as e:
                     self._log.error("Unable to save image: {}", e)
                     return
-                items = lib.items(args)
+                items = lib.items(args, limit=opts.limit)
                 # Confirm with user.
                 if not opts.yes and not _confirm(items, not opts.url):
                     os.remove(tempimg)
@@ -187,7 +190,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     )
                 os.remove(tempimg)
             else:
-                albums = lib.albums(args)
+                albums = lib.albums(args, limit=opts.limit)
                 # Confirm with user.
                 if not opts.yes and not _confirm(albums, not opts.file):
                     return
@@ -203,6 +206,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     )
                     self.remove_artfile(album)
 
+        embed_cmd.parser.add_limit_option()
         embed_cmd.func = embed_func
 
         # Extract command.
@@ -229,7 +233,9 @@ class EmbedCoverArtPlugin(BeetsPlugin):
         ) -> None:
             if opts.outpath:
                 art.extract_first(
-                    self._log, normpath(opts.outpath), lib.items(args)
+                    self._log,
+                    normpath(opts.outpath),
+                    lib.items(args, limit=opts.limit),
                 )
             else:
                 filename = bytestring_path(
@@ -240,7 +246,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                         "Only specify a name rather than a path for -n"
                     )
                     return
-                for album in lib.albums(args):
+                for album in lib.albums(args, limit=opts.limit):
                     if opts.associate and (
                         artpath := art.extract_first(
                             self._log,
@@ -251,6 +257,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                         album.set_art(artpath)
                         album.store()
 
+        extract_cmd.parser.add_limit_option()
         extract_cmd.func = extract_func
 
         # Clear command.
@@ -264,12 +271,13 @@ class EmbedCoverArtPlugin(BeetsPlugin):
         def clear_func(
             lib: Library, opts: ClearArtCLIOpts, args: list[str]
         ) -> None:
-            items = lib.items(args)
+            items = lib.items(args, limit=opts.limit)
             # Confirm with user.
             if not opts.yes and not _confirm(items, False):
                 return
-            art.clear(self._log, lib, args)
+            art.clear(self._log, lib, args, opts.limit)
 
+        clear_cmd.parser.add_limit_option()
         clear_cmd.func = clear_func
 
         return [embed_cmd, extract_cmd, clear_cmd]

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -35,6 +35,7 @@ class ExportCLIOpts(Protocol):
     album: bool
     append: bool
     included_keys: Sequence[str]
+    limit: int | None
     output: str | None
     format: Format | None
 
@@ -132,6 +133,7 @@ class ExportPlugin(BeetsPlugin):
             default=self.config["default_format"].get(),
             help="the output format: json|jsonlines|csv|xml",
         )
+        cmd.parser.add_limit_option(flags=("--limit",))
         return [cmd]
 
     def run(
@@ -167,7 +169,9 @@ class ExportPlugin(BeetsPlugin):
         ]
 
         def collect_data() -> Iterator[JSONDict]:
-            for data_emitter in data_collector(lib, args, album=opts.album):
+            for data_emitter in data_collector(
+                lib, args, album=opts.album, limit=opts.limit
+            ):
                 try:
                     data, _ = data_emitter(included_keys or "*")
                 except (mediafile.UnreadableFileError, OSError) as ex:

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 class FetchArtCLIOpts(Protocol):
     force: bool
+    limit: int | None
     quiet: bool
 
 
@@ -1563,9 +1564,12 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             default=False,
             help="quiet mode: do not output albums that already have artwork",
         )
+        cmd.parser.add_limit_option()
 
         def func(lib: Library, opts: FetchArtCLIOpts, args: list[str]) -> None:
-            self.batch_fetch_art(lib, lib.albums(args), opts.force, opts.quiet)
+            self.batch_fetch_art(
+                lib, lib.albums(args, limit=opts.limit), opts.force, opts.quiet
+            )
 
         cmd.func = func
         return [cmd]

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -243,6 +243,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
             default=None,
             help="drop featuring from artists and ignore title update",
         )
+        self._command.parser.add_limit_option()
 
         self.import_stages = [self.imported]
         if self.auto:
@@ -262,7 +263,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
             self.config.set_args(opts)
             write = ui.should_write()
 
-            for item in lib.items(args):
+            for item in lib.items(args, limit=opts.limit):
                 if self.ft_in_title(item, item.get("albumartist") or ""):
                     item.store()
                     if write:

--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -30,11 +30,15 @@ class InfoCLIOpts(Protocol):
     included_keys: list[str]
     keys_only: bool | None
     library: bool | None
+    limit: int | None
     summarize: bool | None
 
 
 def tag_data(
-    lib: Library, args: Iterable[str], album: bool = False
+    lib: Library,
+    args: Iterable[str],
+    album: bool = False,
+    limit: int | None = None,
 ) -> Iterator[DataEmitter]:
     query = []
     for arg in args:
@@ -45,7 +49,7 @@ def tag_data(
             query.append(arg)
 
     if query:
-        for item in lib.items(query):
+        for item in lib.items(query, limit=limit):
             yield tag_data_emitter(item.path)
 
 
@@ -84,9 +88,14 @@ def tag_data_emitter(path: bytes) -> DataEmitter:
 
 
 def library_data(
-    lib: Library, args: Sequence[str], album: bool = False
+    lib: Library,
+    args: Sequence[str],
+    album: bool = False,
+    limit: int | None = None,
 ) -> Iterator[DataEmitter]:
-    for item in lib.albums(args) if album else lib.items(args):
+    for item in (
+        lib.albums(args, limit=limit) if album else lib.items(args, limit=limit)
+    ):
         yield library_data_emitter(item)
 
 
@@ -194,6 +203,7 @@ class InfoPlugin(BeetsPlugin):
             "-k", "--keys-only", action="store_true", help="show only the keys"
         )
         cmd.parser.add_format_option(target="item")
+        cmd.parser.add_limit_option(flags=("--limit",))
         return [cmd]
 
     def run(self, lib: Library, opts: InfoCLIOpts, args: list[str]) -> None:
@@ -223,7 +233,9 @@ class InfoPlugin(BeetsPlugin):
 
         first = True
         summary: dict[str, Any] = {}
-        for data_emitter in data_collector(lib, args, album=opts.album):
+        for data_emitter in data_collector(
+            lib, args, album=opts.album, limit=opts.limit
+        ):
             try:
                 data, item = data_emitter(included_keys or "*")
             except (mediafile.UnreadableFileError, OSError) as ex:

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -26,6 +26,7 @@ class IPFSCLIOpts(Protocol):
     _list: bool | None
     add: bool | None
     get: bool | None
+    limit: int | None
     play: bool | None
     publish: bool | None
 
@@ -77,7 +78,7 @@ class IPFSPlugin(BeetsPlugin):
 
         def func(lib: Library, opts: IPFSCLIOpts, args: list[str]) -> None:
             if opts.add:
-                for album in lib.albums(args):
+                for album in lib.albums(args, limit=opts.limit):
                     if len(album.items()) == 0:
                         self._log.info(
                             "{} does not contain items, aborting", album
@@ -96,11 +97,12 @@ class IPFSPlugin(BeetsPlugin):
                 self.ipfs_import(lib, args)
 
             if opts._list:
-                self.ipfs_list(lib, args)
+                self.ipfs_list(lib, args, opts.limit)
 
             if opts.play:
                 self.ipfs_play(lib, opts, args)
 
+        cmd.parser.add_limit_option(flags=("--limit",))
         cmd.func = func
         return [cmd]
 
@@ -118,7 +120,7 @@ class IPFSPlugin(BeetsPlugin):
         config["play"]["relative_to"] = None
         # set opts that `_play_command` expects
         play_opts = SimpleNamespace(
-            album=True, randomize=None, args=None, yes=None
+            album=True, limit=opts.limit, randomize=None, args=None, yes=None
         )
         with self.remote_lib(lib) as jlib:
             player._play_command(jlib, play_opts, args)
@@ -265,10 +267,12 @@ class IPFSPlugin(BeetsPlugin):
                 return True
         return False
 
-    def ipfs_list(self, lib: Library, args: Sequence[str]) -> None:
+    def ipfs_list(
+        self, lib: Library, args: Sequence[str], limit: int | None = None
+    ) -> None:
         fmt = config["format_album"].get()
         try:
-            albums = self.query(lib, args)
+            albums = self.query(lib, args, limit=limit)
         except OSError:
             ui.print_("No imported libraries yet.")
             return
@@ -276,9 +280,11 @@ class IPFSPlugin(BeetsPlugin):
         for album in albums:
             ui.print_(format(album, fmt), " : ", album.ipfs.decode())
 
-    def query(self, lib: Library, args: str | Sequence[str]) -> Results[Album]:
+    def query(
+        self, lib: Library, args: str | Sequence[str], limit: int | None = None
+    ) -> Results[Album]:
         with self.remote_lib(lib) as rlib:
-            return rlib.albums(args)
+            return rlib.albums(args, limit=limit)
 
     def _remote_libs_path(self, lib: Library) -> bytes:
         lib_root = os.path.dirname(os.fsencode(lib.path))

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -118,9 +118,10 @@ class IPFSPlugin(BeetsPlugin):
 
         player = PlayPlugin()
         config["play"]["relative_to"] = None
+        limit = opts.limit if opts else None
         # set opts that `_play_command` expects
         play_opts = SimpleNamespace(
-            album=True, limit=opts.limit, randomize=None, args=None, yes=None
+            album=True, limit=limit, randomize=None, args=None, yes=None
         )
         with self.remote_lib(lib) as jlib:
             player._play_command(jlib, play_opts, args)

--- a/beetsplug/keyfinder.py
+++ b/beetsplug/keyfinder.py
@@ -29,13 +29,16 @@ class KeyFinderPlugin(BeetsPlugin):
         cmd = ui.Subcommand(
             "keyfinder", help="detect and add initial key from audio"
         )
+        cmd.parser.add_limit_option()
         cmd.func = self.command
         return [cmd]
 
     def command(
         self, lib: Library, opts: optparse.Values, args: list[str]
     ) -> None:
-        self.find_key(lib.items(args), write=ui.should_write())
+        self.find_key(
+            lib.items(args, limit=opts.limit), write=ui.should_write()
+        )
 
     def imported(self, session: ImportSession, task: ImportTask) -> None:
         self.find_key(task.imported_items())

--- a/beetsplug/limit.py
+++ b/beetsplug/limit.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 class LsLimitCLIOpts(Protocol):
     album: bool
     head: int | None
+    limit: int | None
     tail: int | None
 
 
@@ -42,9 +43,9 @@ def lslimit(lib: Library, opts: LsLimitCLIOpts, args: list[str]) -> None:
 
     objs: Iterable[LibModel]
     if opts.album:
-        objs = lib.albums(args)
+        objs = lib.albums(args, limit=opts.limit)
     else:
-        objs = lib.items(args)
+        objs = lib.items(args, limit=opts.limit)
 
     if opts.head is not None:
         objs = islice(objs, opts.head)
@@ -66,6 +67,7 @@ lslimit_cmd.parser.add_option(
 )
 
 lslimit_cmd.parser.add_all_common_options()
+lslimit_cmd.parser.add_limit_option()
 lslimit_cmd.func = lslimit
 
 

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
 
 
 class LyricsCLIOpts(Protocol):
+    limit: int | None
     print: bool
     rest_directory: str | None
 
@@ -1197,7 +1198,7 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             # The "write to files" option corresponds to the
             # import_write config value.
             self.config.set(vars(opts))
-            items = list(lib.items(args))
+            items = list(lib.items(args, limit=opts.limit))
             for item in items:
                 self.add_item_lyrics(item, ui.should_write())
                 if item.lyrics and opts.print:
@@ -1208,6 +1209,7 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             ):
                 RestFiles(Path(opts.rest_directory).expanduser()).write(items)
 
+        cmd.parser.add_limit_option(flags=("--limit",))
         cmd.func = func
         return [cmd]
 

--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -88,9 +88,10 @@ class MBSubmitPlugin(BeetsPlugin):
         )
 
         def func(lib: Library, opts: optparse.Values, args: list[str]) -> None:
-            items = lib.items(args)
+            items = lib.items(args, limit=opts.limit)
             self._mbsubmit(items)
 
+        mbsubmit_cmd.parser.add_limit_option()
         mbsubmit_cmd.func = func
 
         return [mbsubmit_cmd]

--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 
 class MBSyncCLIOpts(Protocol):
+    limit: int | None
     move: bool | None
     pretend: bool
     write: bool | None
@@ -57,6 +58,7 @@ class MBSyncPlugin(BeetsPlugin):
             help="don't write updated metadata to files",
         )
         cmd.parser.add_format_option()
+        cmd.parser.add_limit_option()
         cmd.func = self.func
         return [cmd]
 
@@ -66,8 +68,8 @@ class MBSyncPlugin(BeetsPlugin):
         pretend = opts.pretend
         write = ui.should_write(opts.write)
 
-        self.singletons(lib, args, move, pretend, write)
-        self.albums(lib, args, move, pretend, write)
+        self.singletons(lib, args, move, pretend, write, opts.limit)
+        self.albums(lib, args, move, pretend, write, opts.limit)
 
     def singletons(
         self,
@@ -76,11 +78,12 @@ class MBSyncPlugin(BeetsPlugin):
         move: bool,
         pretend: bool,
         write: bool,
+        limit: int | None,
     ) -> None:
         """Retrieve and apply info from the autotagger for items matched by
         query.
         """
-        for item in lib.items([*query, "singleton:true"]):
+        for item in lib.items([*query, "singleton:true"], limit=limit):
             if not (track_id := item.mb_trackid):
                 self._log.info(
                     "Skipping singleton with no mb_trackid: {}", item
@@ -111,12 +114,13 @@ class MBSyncPlugin(BeetsPlugin):
         move: bool,
         pretend: bool,
         write: bool,
+        limit: int | None,
     ) -> None:
         """Retrieve and apply info from the autotagger for albums matched by
         query and their items.
         """
         # Process matching albums.
-        for album in lib.albums(query):
+        for album in lib.albums(query, limit=limit):
             if not (album_id := album.mb_albumid):
                 self._log.info("Skipping album with no mb_albumid: {}", album)
                 continue

--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -25,6 +25,7 @@ SOURCES = {"amarok": "Amarok", "itunes": "Itunes"}
 
 
 class MetaSyncCLIOpts(Protocol):
+    limit: int | None
     pretend: bool | None
     sources: list[str]
 
@@ -90,6 +91,7 @@ class MetaSyncPlugin(BeetsPlugin):
             help="comma-separated list of sources to sync",
         )
         cmd.parser.add_format_option()
+        cmd.parser.add_limit_option()
         cmd.func = self.func
         return [cmd]
 
@@ -106,7 +108,7 @@ class MetaSyncPlugin(BeetsPlugin):
         sources = sources or self.config["source"].as_str_seq()
 
         meta_source_instances = {}
-        items = lib.items(args)
+        items = lib.items(args, limit=opts.limit)
 
         # Avoid needlessly instantiating meta sources (can be expensive)
         if not items:

--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -153,6 +153,7 @@ class MissingPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             ),
         )
         self._command.parser.add_format_option()
+        self._command.parser.add_limit_option()
 
     def commands(self) -> list[Subcommand]:
         def _miss(lib: Library, opts: optparse.Values, args: list[str]) -> None:
@@ -160,16 +161,18 @@ class MissingPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             albms = self.config["album"].get()
 
             helper = self._missing_albums if albms else self._missing_tracks
-            helper(lib, args)
+            helper(lib, args, opts.limit)
 
         self._command.func = _miss
         return [self._command]
 
-    def _missing_tracks(self, lib: Library, query: list[str]) -> None:
+    def _missing_tracks(
+        self, lib: Library, query: list[str], limit: int | None
+    ) -> None:
         """Print a listing of tracks missing from each album in the library
         matching query.
         """
-        albums = lib.albums(query)
+        albums = lib.albums(query, limit=limit)
 
         count = self.config["count"].get()
         total = self.config["total"].get()
@@ -192,7 +195,9 @@ class MissingPlugin(MusicBrainzAPIMixin, BeetsPlugin):
                 for item in self._missing(album):
                     print_(format(item, fmt))
 
-    def _missing_albums(self, lib: Library, query: list[str]) -> None:
+    def _missing_albums(
+        self, lib: Library, query: list[str], limit: int | None
+    ) -> None:
         """Print a listing of albums missing from each artist in the library
         matching query.
         """
@@ -200,7 +205,7 @@ class MissingPlugin(MusicBrainzAPIMixin, BeetsPlugin):
 
         # build dict mapping artist to set of their release group ids in library
         album_ids_by_artist = defaultdict(set)
-        for album in lib.albums(query):
+        for album in lib.albums(query, limit=limit):
             # TODO(@snejus): Some releases have different `albumartist` for the
             # same `mb_albumartistid`. Since we're grouping by the combination
             # of these two fields, we end up processing the same

--- a/beetsplug/parentwork.py
+++ b/beetsplug/parentwork.py
@@ -38,7 +38,7 @@ class ParentWorkPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             force_parent = self.config["force"].get(bool)
             write = ui.should_write()
 
-            for item in lib.items(args):
+            for item in lib.items(args, limit=opts.limit):
                 changed = self.find_work(item, force_parent, verbose=True)
                 if changed:
                     item.store()
@@ -58,6 +58,7 @@ class ParentWorkPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             help="re-fetch when parent work is already present",
         )
 
+        command.parser.add_limit_option()
         command.func = func
         return [command]
 

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -31,6 +31,7 @@ ARGS_MARKER = "$args"
 class PlayCLIOpts(Protocol):
     album: bool
     args: str | None
+    limit: int | None
     randomize: bool | None
     yes: bool | None
 
@@ -109,6 +110,7 @@ class PlayPlugin(BeetsPlugin):
             action="store_true",
             help="skip the warning threshold",
         )
+        play_command.parser.add_limit_option()
         play_command.func = self._play_command
         return [play_command]
 
@@ -126,7 +128,7 @@ class PlayPlugin(BeetsPlugin):
         # playlist.
         selection: Sequence[LibModel]
         if opts.album:
-            selection = lib.albums(args)
+            selection = lib.albums(args, limit=opts.limit)
             paths = []
 
             sort = lib.get_default_album_sort()
@@ -139,7 +141,7 @@ class PlayPlugin(BeetsPlugin):
 
         # Perform item query and add tracks to playlist.
         else:
-            selection = lib.items(args)
+            selection = lib.items(args, limit=opts.limit)
             paths = [item.path for item in selection]
             item_type = "track"
 

--- a/beetsplug/random.py
+++ b/beetsplug/random.py
@@ -20,6 +20,7 @@ class RandomCLIOpts(Protocol):
     album: bool
     equal_chance: bool
     field: str
+    limit: int | None
     number: int
     time: float | None
 
@@ -27,7 +28,11 @@ class RandomCLIOpts(Protocol):
 def random_func(lib: Library, opts: RandomCLIOpts, args: list[str]) -> None:
     """Select some random items or albums and print the results."""
     # Fetch all the objects matching the query into a list.
-    objs = lib.albums(args) if opts.album else lib.items(args)
+    objs = (
+        lib.albums(args, limit=opts.limit)
+        if opts.album
+        else lib.items(args, limit=opts.limit)
+    )
 
     # Print a random subset.
     for obj in random_objs(
@@ -71,6 +76,7 @@ random_cmd.parser.add_option(
     help="field to use for equal chance sampling (default: albumartist)",
 )
 random_cmd.parser.add_all_common_options()
+random_cmd.parser.add_limit_option()
 random_cmd.func = random_func
 
 

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -22,12 +22,11 @@ class ReplacePlugin(BeetsPlugin):
         cmd = ui.Subcommand(
             "replace", help="replace audio file while keeping tags"
         )
+        cmd.parser.add_limit_option()
         cmd.func = self.run
         return [cmd]
 
-    def run(
-        self, lib: Library, _opts: optparse.Values, args: list[str]
-    ) -> None:
+    def run(self, lib: Library, opts: optparse.Values, args: list[str]) -> None:
         if len(args) < 2:
             raise UserError("Usage: beet replace <query> <new_file_path>")
 
@@ -36,7 +35,7 @@ class ReplacePlugin(BeetsPlugin):
 
         self.file_check(new_file_path)
 
-        item_list = list(lib.items(item_query))
+        item_list = list(lib.items(item_query, limit=opts.limit))
 
         if not item_list:
             raise UserError("No matching songs found.")

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 class ReplayGainCLIOpts(Protocol):
     album: bool
     force: bool
+    limit: int | None
     threads: int | None
     write: bool | None
 
@@ -1606,7 +1607,7 @@ class ReplayGainPlugin(BeetsPlugin):
                 self.open_pool(threads)
 
             if opts.album:
-                albums = lib.albums(args)
+                albums = lib.albums(args, limit=opts.limit)
                 self._log.info(
                     f"Analyzing {len(albums)} albums ~"
                     f" {self.backend_name} backend..."
@@ -1614,7 +1615,7 @@ class ReplayGainPlugin(BeetsPlugin):
                 for album in albums:
                     self.handle_album(album, write, force)
             else:
-                items = lib.items(args)
+                items = lib.items(args, limit=opts.limit)
                 self._log.info(
                     f"Analyzing {len(items)} tracks ~"
                     f" {self.backend_name} backend..."
@@ -1666,5 +1667,6 @@ class ReplayGainPlugin(BeetsPlugin):
             action="store_false",
             help="don't write metadata (opposite of -w)",
         )
+        cmd.parser.add_limit_option()
         cmd.func = self.command_func
         return [cmd]

--- a/beetsplug/scrub.py
+++ b/beetsplug/scrub.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 
 class ScrubCLIOpts(Protocol):
+    limit: int | None
     write: bool
 
 
@@ -55,7 +56,7 @@ class ScrubPlugin(BeetsPlugin):
             lib: Library, opts: ScrubCLIOpts, args: list[str]
         ) -> None:
             # Walk through matching files and remove tags.
-            for item in lib.items(args):
+            for item in lib.items(args, limit=opts.limit):
                 self._log.info("scrubbing: {.filepath}", item)
                 self._scrub_item(item, opts.write)
 
@@ -68,6 +69,7 @@ class ScrubPlugin(BeetsPlugin):
             default=True,
             help="leave tags empty",
         )
+        scrub_cmd.parser.add_limit_option()
         scrub_cmd.func = scrub_func
 
         return [scrub_cmd]

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -43,6 +43,7 @@ class SpotifyCLIOpts(Protocol):
 
 class SpotifySyncCLIOpts(Protocol):
     force_refetch: bool
+    limit: int | None
 
 
 class TrackDetails(TypedDict):
@@ -580,11 +581,12 @@ class SpotifyPlugin(
             default=False,
             help="re-download data when already present",
         )
+        sync_cmd.parser.add_limit_option()
 
         def func(
             lib: Library, opts: SpotifySyncCLIOpts, args: list[str]
         ) -> None:
-            items = lib.items(args)
+            items = lib.items(args, limit=opts.limit)
             self._fetch_info(lib, items, ui.should_write(), opts.force_refetch)
 
         sync_cmd.func = func

--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -60,6 +60,7 @@ class ThumbnailsPlugin(BeetsPlugin):
             default=False,
             help="create Dolphin-compatible thumbnail information (for KDE)",
         )
+        thumbnails_command.parser.add_limit_option()
         thumbnails_command.func = self.process_query
 
         return [thumbnails_command]
@@ -69,7 +70,7 @@ class ThumbnailsPlugin(BeetsPlugin):
     ) -> None:
         self.config.set_args(opts)
         if self._check_local_ok():
-            for album in lib.albums(args):
+            for album in lib.albums(args, limit=opts.limit):
                 self.process_album(album)
 
     def _check_local_ok(self) -> bool:

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -43,6 +43,7 @@ class TidalCLIOpts(Protocol):
 class TidalSyncCLIOpts(Protocol):
     album: bool
     force: bool
+    limit: int | None
     write: bool
 
 
@@ -664,6 +665,7 @@ class TidalPlugin(MetadataSourcePlugin):
             default=False,
             help="write updated tags to media files (default: False)",
         )
+        tidalsync_cmd.parser.add_limit_option()
         tidalsync_cmd.parser.set_usage(
             "Usage: beet tidalsync <query> [options]"
         )
@@ -675,11 +677,15 @@ class TidalPlugin(MetadataSourcePlugin):
 
             if opts.album:
                 self.sync_album_popularity(
-                    lib.albums(query), write=opts.write, force=opts.force
+                    lib.albums(query, limit=opts.limit),
+                    write=opts.write,
+                    force=opts.force,
                 )
             else:
                 self.sync_item_popularity(
-                    lib.items(query), write=opts.write, force=opts.force
+                    lib.items(query, limit=opts.limit),
+                    write=opts.write,
+                    force=opts.force,
                 )
 
         tidalsync_cmd.func = sync_func

--- a/beetsplug/titlecase.py
+++ b/beetsplug/titlecase.py
@@ -159,13 +159,14 @@ class TitlecasePlugin(BeetsPlugin):
     def commands(self) -> list[ui.Subcommand]:
         def func(lib: Library, opts: optparse.Values, args: list[str]) -> None:
             write = ui.should_write()
-            for item in lib.items(args):
+            for item in lib.items(args, limit=opts.limit):
                 self._log.info(f"titlecasing {item.title}:")
                 self.titlecase_fields(item)
                 item.store()
                 if write:
                     item.try_write()
 
+        self._command.parser.add_limit_option()
         self._command.func = func
         return [self._command]
 

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -90,9 +90,10 @@ class ZeroPlugin(BeetsPlugin):
                 "Remove fields for all items? (Y/n)", True
             ):
                 return
-            for item in lib.items(args):
+            for item in lib.items(args, limit=opts.limit):
                 self.process_item(item)
 
+        zero_command.parser.add_limit_option()
         zero_command.func = zero_fields
         return [zero_command]
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,9 +9,11 @@ below!
 Unreleased
 ----------
 
-..
-    New features
-    ~~~~~~~~~~~~
+New features
+~~~~~~~~~~~~
+
+- Add ``-l / --limit LIMIT`` to other query-based commands. Commands that
+  already use ``-l`` for another purpose accept ``--limit LIMIT`` only.
 
 ..
     Bug fixes

--- a/docs/dev/plugins/commands.rst
+++ b/docs/dev/plugins/commands.rst
@@ -49,6 +49,6 @@ Try running ``pydoc beets.ui`` to see what's available.
 You can add command-line options to your new command using the ``parser`` member
 of the ``Subcommand`` class, which is a ``CommonOptionsParser`` instance. Just
 use it like you would a normal ``OptionParser`` in an independent script. Note
-that it offers several methods to add common options: ``--album``, ``--path``
-and ``--format``. This feature is versatile and extensively documented, try
-``pydoc beets.ui.CommonOptionsParser`` for more information.
+that it offers several methods to add common options: ``--album``, ``--path``,
+``--format``, and ``--limit``. This feature is versatile and extensively
+documented, try ``pydoc beets.ui.CommonOptionsParser`` for more information.

--- a/docs/plugins/absubmit.rst
+++ b/docs/plugins/absubmit.rst
@@ -34,12 +34,13 @@ To run the analysis program and upload its results, type:
 
 ::
 
-    beet absubmit [-f] [-d] [QUERY]
+    beet absubmit [-f] [-d] [-l LIMIT] [QUERY]
 
 By default, the command will only look for AcousticBrainz data when the tracks
 don't already have it; the ``-f`` or ``--force`` switch makes it refetch data
 even when it already exists. You can use the ``-d`` or ``--dry`` switch to check
 which files will be analyzed, before you start a longer period of processing.
+Use ``-l``/``--limit`` to cap the matched tracks before analysis.
 
 The plugin works on music with a MusicBrainz track ID attached. The plugin will
 also skip music that the analysis tool doesn't support.

--- a/docs/plugins/acousticbrainz.rst
+++ b/docs/plugins/acousticbrainz.rst
@@ -16,12 +16,13 @@ Enable the ``acousticbrainz`` plugin in your configuration (see
 
 ::
 
-    $ beet acousticbrainz [-f] [QUERY]
+    $ beet acousticbrainz [-f] [-l LIMIT] [QUERY]
 
 By default, the command will only look for AcousticBrainz data when the tracks
 doesn't already have it; the ``-f`` or ``--force`` switch makes it re-download
 data even when it already exists. If you specify a query, only matching tracks
 will be processed; otherwise, the command processes every track in your library.
+Use ``-l``/``--limit`` to cap the matched tracks before fetching data.
 
 For all tracks with a MusicBrainz recording ID, the plugin currently sets these
 fields:

--- a/docs/plugins/autobpm.rst
+++ b/docs/plugins/autobpm.rst
@@ -3,8 +3,8 @@ AutoBPM Plugin
 
 The ``autobpm`` plugin uses the Librosa_ library to calculate the BPM of a track
 from its audio data and store it in the ``bpm`` field of your database. It does
-so automatically when importing music or through the ``beet autobpm [QUERY]``
-command.
+so automatically when importing music or through the ``beet autobpm [-l LIMIT]
+[QUERY]`` command.
 
 Install
 -------
@@ -41,8 +41,9 @@ Default
 .. conf:: force
     :default: no
 
-    Calculate a BPM even for files that already have a ``bpm`` value. Can also be set
-    using the ``-f`` or ``--force`` flag.
+    Calculate a BPM even for files that already have a ``bpm`` value. Can also
+    be set using the ``-f`` or ``--force`` flag. Use ``-l``/``--limit`` to cap
+    the matched tracks before calculating BPM.
 
 .. conf:: overwrite
     :default: no

--- a/docs/plugins/badfiles.rst
+++ b/docs/plugins/badfiles.rst
@@ -53,6 +53,8 @@ instance, this will run a check on all songs containing the word "wolf":
 
     beet bad wolf
 
+Use ``-l``/``--limit`` to cap the matched tracks before checking files.
+
 This one will run checks on a specific album:
 
 ::

--- a/docs/plugins/bareasc.rst
+++ b/docs/plugins/bareasc.rst
@@ -24,7 +24,8 @@ command. This command is **exactly** the same as the ``beet list`` command
 except that the output is passed through the bare-ASCII transformation before
 being printed. This allows you to easily check what the library data looks like
 in bare ASCII, which can be useful if you are trying to work out why a query is
-not matching.
+not matching. Use ``-l``/``--limit`` to cap the matched tracks or albums before
+printing.
 
 Using the same example track as above:
 

--- a/docs/plugins/bpm.rst
+++ b/docs/plugins/bpm.rst
@@ -14,7 +14,7 @@ Then, play a song you want to measure in your favorite media player and type:
 
 ::
 
-    beet bpm <song>
+    beet bpm [-l LIMIT] <song>
 
 You'll be prompted to press Enter three times to the rhythm. This typically
 allows to determine the BPM within 5% accuracy.
@@ -24,7 +24,9 @@ instance, with ``mpc`` you can do something like:
 
 ::
 
-    beet bpm $(mpc |head -1|tr -d "-")
+    beet bpm [-l LIMIT] $(mpc |head -1|tr -d "-")
+
+Use ``-l``/``--limit`` to cap the matched tracks before choosing a song.
 
 If :ref:`import.write <config-import-write>` is ``yes``, the song's tags are
 written to disk.

--- a/docs/plugins/bpsync.rst
+++ b/docs/plugins/bpsync.rst
@@ -35,3 +35,4 @@ The command has a few command-line options:
 - If you have the ``import.write`` configuration option enabled, then this
   plugin will write new metadata to files' tags. To disable this, use the ``-W``
   (``--nowrite``) option.
+- To cap the matched tracks or albums before syncing, use ``-l``/``--limit``.

--- a/docs/plugins/chroma.rst
+++ b/docs/plugins/chroma.rst
@@ -161,7 +161,8 @@ short token string. Then, add the key to your ``config.yaml`` as the value
         apikey: AbCd1234
 
 Then, run ``beet submit``. (You can also provide a query to submit a subset of
-your library.) The command will use stored fingerprints if they're available;
+your library.) Use ``-l``/``--limit`` to cap the matched tracks before
+submitting. The command will use stored fingerprints if they're available;
 otherwise it will fingerprint each file before submitting it.
 
 .. _get an api key: https://acoustid.org/api-key
@@ -196,7 +197,8 @@ to restrict the search:
     beet chromasearch -s FINGERPRINT artist:"rolling stones"
 
 By default, the command returns the top 5 closest matches in your library. You
-can change the number of results using the ``-c`` (``--count``) option.
+can change the number of results using the ``-c`` (``--count``) option. Use
+``-l``/``--limit`` to cap the tracks searched before ranking results.
 
 When an exact match is found, the search normally stops early. To continue
 searching for additional similar items even after an exact match, use the

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -21,10 +21,12 @@ Usage
 
 To convert a part of your collection, run ``beet convert QUERY``. The command
 will transcode all the files matching the query to the destination directory
-given by the ``-d`` (``--dest``) option or the ``dest`` configuration. The path
-layout mirrors that of your library, but it may be customized through the
-``paths`` configuration. Files that have been previously converted---and thus
-already exist in the destination directory---will be skipped.
+given by the ``-d`` (``--dest``) option or the ``dest`` configuration. Use
+``--limit`` to cap the matched items or albums before conversion; the short
+``-l`` option is already used by ``--link``. The path layout mirrors that of
+your library, but it may be customized through the ``paths`` configuration.
+Files that have been previously converted---and thus already exist in the
+destination directory---will be skipped.
 
 The plugin uses a command-line program to transcode the audio. With the ``-f``
 (``--format``) option you can choose the transcoding command and customize the

--- a/docs/plugins/deezer.rst
+++ b/docs/plugins/deezer.rst
@@ -56,4 +56,5 @@ Commands
 The ``deezer`` plugin provides an additional command ``deezerupdate`` to update
 the ``rank`` information from Deezer. The ``rank`` (ranges from 0 to 1M) is a
 global indicator of a song's popularity on Deezer that is updated daily based on
-streams. The higher the ``rank``, the more popular the track is.
+streams. The higher the ``rank``, the more popular the track is. Use
+``-l``/``--limit`` to cap the matched tracks before updating ranks.

--- a/docs/plugins/duplicates.rst
+++ b/docs/plugins/duplicates.rst
@@ -95,6 +95,9 @@ file. The available options mirror the command-line options:
 Examples
 --------
 
+Use ``-l``/``--limit`` to cap the matched tracks or albums before detecting
+duplicates.
+
 List all duplicate tracks in your collection:
 
 ::

--- a/docs/plugins/embedart.rst
+++ b/docs/plugins/embedart.rst
@@ -88,31 +88,32 @@ Manually Embedding and Extracting Art
 The ``embedart`` plugin provides a couple of commands for manually managing
 embedded album art:
 
-- ``beet embedart [-f IMAGE] QUERY``: embed images in every track of the albums
-  matching the query. If the ``-f`` (``--file``) option is given, then use a
-  specific image file from the filesystem; otherwise, each album embeds its own
-  currently associated album art. The command prompts for confirmation before
-  making the change unless you specify the ``-y`` (``--yes``) option.
-- ``beet embedart [-u IMAGE_URL] QUERY``: embed image specified in the URL into
-  every track of the albums matching the query. The ``-u`` (``--url``) option
-  can be used to specify the URL of the image to be used. The command prompts
-  for confirmation before making the change unless you specify the ``-y``
+- ``beet embedart [-f IMAGE] [-l LIMIT] QUERY``: embed images in every track of
+  the albums matching the query. If the ``-f`` (``--file``) option is given,
+  then use a specific image file from the filesystem; otherwise, each album
+  embeds its own currently associated album art. The command prompts for
+  confirmation before making the change unless you specify the ``-y``
   (``--yes``) option.
-- ``beet extractart [-a] [-n FILE] QUERY``: extracts the images for all albums
-  matching the query. The images are placed inside the album folder. You can
-  specify the destination file name using the ``-n`` option, but leave off the
-  extension: it will be chosen automatically. The destination filename is
-  specified using the ``art_filename`` configuration option. It defaults to
+- ``beet embedart [-u IMAGE_URL] [-l LIMIT] QUERY``: embed image specified in
+  the URL into every track of the albums matching the query. The ``-u``
+  (``--url``) option can be used to specify the URL of the image to be used. The
+  command prompts for confirmation before making the change unless you specify
+  the ``-y`` (``--yes``) option.
+- ``beet extractart [-a] [-n FILE] [-l LIMIT] QUERY``: extracts the images for
+  all albums matching the query. The images are placed inside the album folder.
+  You can specify the destination file name using the ``-n`` option, but leave
+  off the extension: it will be chosen automatically. The destination filename
+  is specified using the ``art_filename`` configuration option. It defaults to
   ``cover`` if it's not specified via ``-o`` nor the config. Using ``-a``, the
   extracted image files are automatically associated with the corresponding
   album.
-- ``beet extractart -o FILE QUERY``: extracts the image from an item matching
-  the query and stores it in a file. You have to specify the destination file
-  using the ``-o`` option, but leave off the extension: it will be chosen
-  automatically.
-- ``beet clearart QUERY``: removes all embedded images from all items matching
-  the query. The command prompts for confirmation before making the change
-  unless you specify the ``-y`` (``--yes``) option. The files listed for
+- ``beet extractart -o FILE [-l LIMIT] QUERY``: extracts the image from an item
+  matching the query and stores it in a file. You have to specify the
+  destination file using the ``-o`` option, but leave off the extension: it will
+  be chosen automatically.
+- ``beet clearart [-l LIMIT] QUERY``: removes all embedded images from all items
+  matching the query. The command prompts for confirmation before making the
+  change unless you specify the ``-y`` (``--yes``) option. The files listed for
   confirmation are the ones matching the query independently of having an
   embedded art. However, only the files with an embedded art are updated,
   leaving untouched the files without.

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -33,6 +33,9 @@ The ``export`` command has these command-line options:
 
       $ beet export -i 'title,mb*' beatles
 
+- ``--limit``: Cap the matched items or albums before exporting. The short
+  ``-l`` option is already used by ``--library``.
+
   will include the ``title`` property and all properties starting with ``mb``.
   You can add the ``-i`` option multiple times to the command line.
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -139,7 +139,7 @@ been imported:
 
 ::
 
-    $ beet fetchart [-f] [query]
+    $ beet fetchart [-f] [-l LIMIT] [query]
 
 By default, the command will only look for album art when the album doesn't
 already have it; the ``-f`` or ``--force`` switch makes it search for art in Web
@@ -154,7 +154,9 @@ missing art:
 
 ::
 
-    $ beet fetchart [-q] [query]
+    $ beet fetchart [-q] [-l LIMIT] [query]
+
+Use ``-l``/``--limit`` to cap the matched albums before fetching art.
 
 By default the command will display all albums matching the ``query``. When the
 ``-q`` or ``--quiet`` switch is given, only albums for which artwork has been

--- a/docs/plugins/ftintitle.rst
+++ b/docs/plugins/ftintitle.rst
@@ -61,10 +61,10 @@ From the command line, type:
 
 ::
 
-    $ beet ftintitle [QUERY]
+    $ beet ftintitle [-l LIMIT] [QUERY]
 
 The query is optional; if it's left off, the transformation will be applied to
-your entire collection.
+your entire collection. Use ``-l``/``--limit`` to cap the matched tracks.
 
 Use the ``-d`` flag to remove featured artists (equivalent of the ``drop``
 config option).

--- a/docs/plugins/info.rst
+++ b/docs/plugins/info.rst
@@ -22,6 +22,9 @@ library:
 
     $ beet info beatles
 
+Use ``--limit`` to cap the matched items or albums before printing information.
+The short ``-l`` option is already used by ``--library``.
+
 If you just want to see specific properties you can use the ``--include-keys``
 option to filter them. The argument is a comma-separated list of field names.
 For example:

--- a/docs/plugins/ipfs.rst
+++ b/docs/plugins/ipfs.rst
@@ -57,12 +57,14 @@ already exist in the joined library.
 When remote libraries has been imported you can search them by using the ``-l``
 or ``--list`` flag. The hash of albums matching the query will be returned, and
 this can then be used with ``-g`` to fetch and import the album to the local
-library.
+library. Use ``--limit`` to cap matched albums; the short ``-l`` option is
+already used by ``--list``.
 
 Ipfs can be mounted as a FUSE file system. This means that music in a remote
 library can be streamed directly, without importing them to the local library
 first. If the ``/ipfs`` folder is mounted then matching queries will be sent to
-the :doc:`/plugins/play` using the ``-m`` or ``--play`` flag.
+the :doc:`/plugins/play` using the ``-m`` or ``--play`` flag. Use ``--limit`` to
+cap the matched remote albums before generating the playlist.
 
 Configuration
 -------------

--- a/docs/plugins/keyfinder.rst
+++ b/docs/plugins/keyfinder.rst
@@ -4,7 +4,7 @@ Key Finder Plugin
 The ``keyfinder`` plugin uses either the KeyFinder_ or keyfinder-cli_ program to
 detect the musical key of a track from its audio data and store it in the
 ``initial_key`` field of your database. It does so automatically when importing
-music or through the ``beet keyfinder [QUERY]`` command.
+music or through the ``beet keyfinder [-l LIMIT] [QUERY]`` command.
 
 To use the ``keyfinder`` plugin, enable it in your configuration (see
 :ref:`using-plugins`).

--- a/docs/plugins/limit.rst
+++ b/docs/plugins/limit.rst
@@ -3,12 +3,12 @@ Limit Query Plugin
 
 .. deprecated:: 2.14
 
-    Use the built-in ``-l`` / ``--limit`` flag on the :ref:`list-cmd` command
+    Use the built-in ``-l`` / ``--limit`` option on query-based commands
     instead.
 
 ``limit`` is a plugin to limit a query to the first or last set of results. We
-also provide a query prefix ``'<n'`` to inline the same behavior in the ``list``
-command. They are analogous to piping results:
+also provide a query prefix ``'<n'`` to inline the same behavior in query-based
+commands. They are analogous to piping results:
 
     $ beet [list|ls] [QUERY] | [head|tail] -n n
 
@@ -17,7 +17,7 @@ There are two provided interfaces:
 1. ``beet lslimit [--head n | --tail n] [QUERY]`` returns the head or tail of a
 query
 
-2. ``beet [list|ls] [QUERY] '<n'`` returns the head of a query
+2. ``beet [QUERY_COMMAND] [QUERY] '<n'`` returns the head of a query
 
 There are two differences in behavior:
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -156,7 +156,9 @@ lyrics will be added to the beets database and, if ``import.write`` is on,
 embedded into files' metadata.
 
 The ``-p, --print`` option to the ``lyrics`` command makes it print lyrics out
-to the console so you can view the fetched (or previously-stored) lyrics.
+to the console so you can view the fetched (or previously-stored) lyrics. Use
+``--limit`` to cap the matched tracks before fetching lyrics. The short ``-l``
+option is already used by ``--local``.
 
 The ``-f, --force`` option forces the command to fetch lyrics, even for tracks
 that already have lyrics.

--- a/docs/plugins/mbsubmit.rst
+++ b/docs/plugins/mbsubmit.rst
@@ -49,7 +49,7 @@ choice is demonstrated:
     Print tracks?
 
 You can also run ``beet mbsubmit QUERY`` to print the track information for any
-album:
+album. Use ``-l``/``--limit`` to cap the matched tracks before printing:
 
 ::
 

--- a/docs/plugins/mbsync.rst
+++ b/docs/plugins/mbsync.rst
@@ -37,3 +37,4 @@ The command has a few command-line options:
 - To customize the output of unrecognized items, use the ``-f`` (``--format``)
   option. The default output is ``format_item`` or ``format_album`` for items
   and albums, respectively.
+- To cap the matched tracks or albums before syncing, use ``-l``/``--limit``.

--- a/docs/plugins/metasync.rst
+++ b/docs/plugins/metasync.rst
@@ -56,7 +56,7 @@ Usage
 -----
 
 Run ``beet metasync QUERY`` to fetch metadata from the configured list of
-sources.
+sources. Use ``-l``/``--limit`` to cap the matched tracks before syncing.
 
 The command has a few command-line options:
 

--- a/docs/plugins/missing.rst
+++ b/docs/plugins/missing.rst
@@ -81,6 +81,9 @@ of tracks missing from each album.
 Examples
 --------
 
+Use ``-l``/``--limit`` to cap the matched albums before checking for missing
+tracks or releases.
+
 List all missing tracks in your collection:
 
 ::

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -11,7 +11,8 @@ To use the ``play`` plugin, enable it in your configuration (see
 :ref:`using-plugins`). Then use it by invoking the ``beet play`` command with a
 query. The command will create a temporary m3u file and open it using an
 appropriate application. You can query albums instead of tracks using the ``-a``
-option.
+option. Use ``-l``/``--limit`` to cap the matched tracks or albums before the
+playlist is generated.
 
 By default, the playlist is opened using the ``open`` command on OS X,
 ``xdg-open`` on other Unixes, and ``start`` on Windows. To configure the

--- a/docs/plugins/random.rst
+++ b/docs/plugins/random.rst
@@ -32,6 +32,8 @@ allow you to customize the selection:
       --field=FIELD         field to use for equal chance sampling (default:
                             albumartist)
       -a, --album           match albums instead of tracks
+      -l LIMIT, --limit=LIMIT
+                            limit query results before random selection
       -p PATH, --path=PATH  print paths for matched items or albums
       -f FORMAT, --format=FORMAT
                             print with custom format

--- a/docs/plugins/replace.rst
+++ b/docs/plugins/replace.rst
@@ -10,10 +10,11 @@ and then type:
 
 ::
 
-    $ beet replace <query> <path>
+    $ beet replace [-l LIMIT] <query> <path>
 
 The plugin will show you a list of files for you to pick from, and then ask for
-confirmation.
+confirmation. Use ``-l``/``--limit`` to cap the matched tracks before choosing
+the file to replace.
 
 Consider using the ``replaygain`` command from the :doc:`/plugins/replaygain`
 plugin, if you usually use it during imports.

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -216,7 +216,7 @@ Use the ``beet replaygain`` command:
 
 ::
 
-    $ beet replaygain [-Waf] [QUERY]
+    $ beet replaygain [-Waf] [-l LIMIT] [QUERY]
 
 The ``-a`` flag analyzes whole albums instead of individual tracks. Provide a
 query (see :doc:`/reference/query`) to indicate which items or albums to
@@ -224,14 +224,15 @@ analyze. Files that already have ReplayGain values are skipped unless ``-f`` is
 supplied. Use ``-w`` (write tags) or ``-W`` (don't write tags) to control
 whether ReplayGain tags are written into the music files, or stored in the beets
 database only (the default is to use :ref:`the importer's configuration
-<config-import-write>`).
+<config-import-write>`). Use ``-l``/``--limit`` to cap the matched tracks or
+albums before analysis.
 
 To execute with a different number of threads, call ``beet replaygain --threads
 N``:
 
 ::
 
-    $ beet replaygain --threads N [-Waf] [QUERY]
+    $ beet replaygain --threads N [-Waf] [-l LIMIT] [QUERY]
 
 with N any integer. To disable parallelism, use ``--threads 0``.
 

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -157,11 +157,11 @@ be used for music discovery.
 The ``spotify`` plugin provides an additional command ``spotifysync`` to obtain
 these track attributes from Spotify:
 
-- ``beet spotifysync [-f]``: obtain popularity and audio features information
-  for every track in the library. By default, ``spotifysync`` will skip tracks
-  that already have this information populated. Using the ``-f`` or ``-force``
-  option will download the data even for tracks that already have it. Please
-  note that ``spotifysync`` works on tracks that have the Spotify track
+- ``beet spotifysync [-f] [-l LIMIT]``: obtain popularity and audio features
+  information for every track in the library. By default, ``spotifysync`` will
+  skip tracks that already have this information populated. Using the ``-f`` or
+  ``-force`` option will download the data even for tracks that already have it.
+  Please note that ``spotifysync`` works on tracks that have the Spotify track
   identifiers. So run ``spotifysync`` only after importing your music, during
   which Spotify identifiers will be added for tracks where Spotify is chosen as
   the tag source.

--- a/docs/plugins/thumbnails.rst
+++ b/docs/plugins/thumbnails.rst
@@ -38,4 +38,5 @@ Usage
 -----
 
 The ``thumbnails`` command provided by this plugin creates a thumbnail for
-albums that match a query (see :doc:`/reference/query`).
+albums that match a query (see :doc:`/reference/query`). Use ``-l``/``--limit``
+to cap the matched albums before creating thumbnails.

--- a/docs/plugins/tidal.rst
+++ b/docs/plugins/tidal.rst
@@ -165,6 +165,7 @@ Options:
 - ``-f``, ``--force`` -- re-fetch all items, even those already synced.
 - ``-a``, ``--album`` -- sync albums instead of individual tracks.
 - ``-w``, ``--write`` -- write updated metadata to media files.
+- ``-l``, ``--limit`` -- cap the matched items or albums before syncing.
 
 You can also pass a query to narrow the scope:
 

--- a/docs/plugins/zero.rst
+++ b/docs/plugins/zero.rst
@@ -55,8 +55,8 @@ Note that the plugin currently does not zero fields when importing "as-is".
 Manually Triggering Zero
 ------------------------
 
-You can also type ``beet zero [QUERY]`` to manually invoke the plugin on music
-in your library.
+You can also type ``beet zero [-l LIMIT] [QUERY]`` to manually invoke the plugin
+on music in your library.
 
 Preserving Album Art
 --------------------

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -215,7 +215,9 @@ like ``title:foo`` will be ignored. Remember that ``artist`` is an item-level
 field; ``albumartist`` is the corresponding album field.
 
 Use the ``-l LIMIT`` (``--limit=LIMIT``) flag when you want to cap the maximum
-number of items that are returned.
+number of items or albums that are returned. Many other commands that accept a
+query also support this option. When another command already uses ``-l`` for a
+different purpose, use the long ``--limit`` form instead.
 
 The ``-p`` option makes beets print out filenames of matched items, which might
 be useful for piping into other Unix commands (such as `xargs
@@ -233,7 +235,7 @@ remove
 
 ::
 
-    beet remove [-adf] QUERY
+    beet remove [-adf] [-l LIMIT] QUERY
 
 Remove music from your library.
 
@@ -242,6 +244,8 @@ By default, it just removes entries from the library database; it doesn't touch
 the files on disk. To actually delete the files, use the ``-d`` flag. When the
 ``-a`` flag is given, the command operates on albums instead of individual
 tracks.
+
+Use ``-l``/``--limit`` to cap the matched items or albums before confirmation.
 
 When you run the ``remove`` command, it prints a list of all affected items in
 the library and asks for your permission before removing them. You can then
@@ -262,7 +266,7 @@ modify
 
 ::
 
-    beet modify [-IMWay] [-f FORMAT] QUERY [FIELD=VALUE...] [FIELD+=VALUE...] [FIELD-=VALUE...] [FIELD!...]
+    beet modify [-IMWay] [-f FORMAT] [-l LIMIT] QUERY [FIELD=VALUE...] [FIELD+=VALUE...] [FIELD-=VALUE...] [FIELD!...]
 
 Change the metadata for items or albums in the database.
 
@@ -323,6 +327,8 @@ This option lets you choose precisely which data to change without spending too
 much time to carefully craft a query. To skip the prompts entirely, use the
 ``-y`` option.
 
+Use ``-l``/``--limit`` to cap the matched items or albums before confirmation.
+
 .. _move-cmd:
 
 move
@@ -330,7 +336,7 @@ move
 
 ::
 
-    beet move [-capt] [-d DIR] QUERY
+    beet move [-capt] [-d DIR] [-l LIMIT] QUERY
 
 Move or copy items in your library.
 
@@ -346,6 +352,9 @@ you a list of files that would be moved but won't actually change anything on
 disk. The ``-t`` option sets the timid mode which will ask again before really
 moving or copying the files.
 
+Use ``-l``/``--limit`` to cap the matched items or albums before moving,
+copying, or previewing changes.
+
 .. _update-cmd:
 
 update
@@ -353,7 +362,7 @@ update
 
 ::
 
-    beet update [-F] FIELD [-e] EXCLUDE_FIELD [-aMp] QUERY
+    beet update [-F] FIELD [-e] EXCLUDE_FIELD [-aMpl] QUERY
 
 Update the library (and, by default, move files) to reflect out-of-band metadata
 changes and file deletions.
@@ -368,6 +377,9 @@ edited.
 To perform a "dry run" of an update, just use the ``-p`` (for "pretend") flag.
 This will show you all the proposed changes but won't actually change anything
 on disk.
+
+Use ``-l``/``--limit`` to cap the matched items or albums before reading files
+and applying updates.
 
 By default, all the changed metadata will be populated back to the database. If
 you only want certain fields to be written, specify them with the ``-F`` flags
@@ -390,7 +402,7 @@ write
 
 ::
 
-    beet write [-pf] [QUERY]
+    beet write [-pfl] [QUERY]
 
 Write metadata from the database into files' tags.
 
@@ -409,6 +421,8 @@ The ``-f`` option forces a write to the file, even if the file tags match the
 database. This is useful for making sure that enabled plugins that run on write
 (e.g., the Scrub and Zero plugins) are run on the file.
 
+Use ``-l``/``--limit`` to cap the matched items before writing tags.
+
 .. _stats-cmd:
 
 stats
@@ -416,7 +430,7 @@ stats
 
 ::
 
-    beet stats [-e] [QUERY]
+    beet stats [-el] [QUERY]
 
 Show some statistics on your entire library (if you don't provide a :doc:`query
 <query>`) or the matched items (if you do).
@@ -424,6 +438,8 @@ Show some statistics on your entire library (if you don't provide a :doc:`query
 By default, the command calculates file sizes using their bitrate and duration.
 The ``-e`` (``--exact``) option reads the exact sizes of each file (but is
 slower). The exact mode also outputs the exact duration in seconds.
+
+Use ``-l``/``--limit`` to cap the matched items before calculating statistics.
 
 .. _fields-cmd:
 

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -1072,7 +1072,7 @@ class TestTidalsync(TidalPluginTest):
         self._run_tidalsync("path::aaa")
 
         self.lib.items.assert_called_once_with(
-            ["data_source:tidal", "path::aaa"]
+            ["data_source:tidal", "path::aaa"], limit=None
         )
         self.tidal.sync_item_popularity.assert_called_once_with(
             ["items"], write=False, force=False
@@ -1085,7 +1085,9 @@ class TestTidalsync(TidalPluginTest):
 
         self._run_tidalsync()
 
-        self.lib.items.assert_called_once_with(["data_source:tidal"])
+        self.lib.items.assert_called_once_with(
+            ["data_source:tidal"], limit=None
+        )
         self.tidal.sync_item_popularity.assert_called_once_with(
             ["items"], write=False, force=False
         )
@@ -1099,9 +1101,19 @@ class TestTidalsync(TidalPluginTest):
         self._run_tidalsync("-a", "artist:Test")
 
         self.lib.albums.assert_called_once_with(
-            ["data_source:tidal", "artist:Test"]
+            ["data_source:tidal", "artist:Test"], limit=None
         )
         self.tidal.sync_album_popularity.assert_called_once_with(
             ["albums"], write=False, force=False
         )
         self.tidal.sync_item_popularity.assert_not_called()
+
+    def test_tidalsync_passes_limit_to_query(self):
+        self.lib.items = Mock(return_value=["items"])
+        self.tidal.sync_item_popularity = Mock()
+
+        self._run_tidalsync("--limit", "1", "artist:Test")
+
+        self.lib.items.assert_called_once_with(
+            ["data_source:tidal", "artist:Test"], limit=1
+        )

--- a/test/ui/commands/test_list.py
+++ b/test/ui/commands/test_list.py
@@ -1,8 +1,5 @@
 import os
 
-import pytest
-
-from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 
@@ -82,9 +79,6 @@ class ListTest(IOMixin, BeetsTestCase):
 
         stdout = self.run_with_output(*args, "-l", "1").strip()
         assert len(stdout.splitlines()) == 1
-
-        with pytest.raises(UserError, match="must be a non-negative integer"):
-            self.run_with_output(*args, "-l", "-1")
 
     def test_limit_sort_by_flex_attr(self):
         args = "list", "-p", "-l", "1"

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -452,6 +452,26 @@ class CommonOptionsParserTest(unittest.TestCase):
         parser.parse_args(["-f", "$foo2", "-a"])
         assert config["format_album"].as_str() == "$foo2"
 
+    def test_limit_option(self):
+        parser = ui.CommonOptionsParser()
+        parser.add_limit_option()
+
+        assert parser.parse_args([]) == ({"limit": None}, [])
+        assert parser.parse_args(["-l", "1"]) == ({"limit": 1}, [])
+        assert parser.parse_args(["--limit", "2"]) == ({"limit": 2}, [])
+
+        with pytest.raises(UserError, match="must be a non-negative integer"):
+            parser.parse_args(["-l", "-1"])
+
+    def test_limit_option_with_custom_flags(self):
+        parser = ui.CommonOptionsParser()
+        parser.add_limit_option(flags=("--limit",))
+
+        assert parser.parse_args(["--limit", "1"]) == ({"limit": 1}, [])
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["-l", "1"])
+
     def test_add_all_common_options(self):
         parser = ui.CommonOptionsParser()
         parser.add_all_common_options()


### PR DESCRIPTION
- Added a shared `CommonOptionsParser.add_limit_option()` in `beets.ui` so `limit` parsing and validation now live in one place instead of being reimplemented per command.

- Wired `limit=opts.limit` through core query-based commands and many plugins by passing it directly into `lib.items()` and `lib.albums()`. This makes `--limit` a consistent cross-command capability, not something mostly tied to `list`.

- Kept the CLI shape compatible by using `--limit` only on commands where `-l` was already taken for another meaning, avoiding flag conflicts without adding new command-specific behavior.

- Updated docs and changelog to reflect the broader architecture change: query-based commands now support built-in limiting, and the old `limit` plugin guidance is reframed around that built-in behavior.

- Added parser and integration-oriented test coverage, plus a small `ipfs` follow-up fix, to make sure the new shared option is passed through safely and behaves consistently across commands.

**High-level impact**

- Reviewers can think of this as a consistency pass on the query execution layer: more commands now share the same "match query, optionally cap results, then act" flow.
- User-facing effect is straightforward: expensive or destructive commands can now be safely scoped with `--limit`, which makes them easier to preview and use incrementally.
