### PR TITLE
importer: skip TestImport7z and TestImportRar when optional dependencies are missing

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -92,6 +92,13 @@ NEEDS_FFPROBE = pytest.mark.skipif(
     not has_program("ffprobe", ("-version",)) and not RUNNING_IN_CI,
     reason="ffprobe (ffmpeg) is not available",
 )
+NEEDS_PY7ZR = pytest.mark.skipif(
+    not is_importable("py7zr"), reason="py7zr is not available"
+)
+NEEDS_RARFILE = pytest.mark.skipif(
+    not (is_importable("rarfile") and has_program("unrar")),
+    reason="rarfile or unrar program not found",
+)
 
 
 class ConfigMixin:

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -92,13 +92,6 @@ NEEDS_FFPROBE = pytest.mark.skipif(
     not has_program("ffprobe", ("-version",)) and not RUNNING_IN_CI,
     reason="ffprobe (ffmpeg) is not available",
 )
-NEEDS_PY7ZR = pytest.mark.skipif(
-    not is_importable("py7zr"), reason="py7zr is not available"
-)
-NEEDS_RARFILE = pytest.mark.skipif(
-    not (is_importable("rarfile") and has_program("unrar")),
-    reason="rarfile or unrar program not found",
-)
 
 
 class ConfigMixin:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,9 +13,12 @@ Unreleased
     New features
     ~~~~~~~~~~~~
 
-..
-    Bug fixes
-    ~~~~~~~~~
+Bug fixes
+~~~~~~~~~
+
+- Skip archive importer tests (``TestImport7z`` and ``TestImportRar``) when
+  their optional dependencies (``py7zr`` or ``rarfile`` / ``unrar``) are not
+  available. :bug:`7002`
 
 ..
     For plugin developers

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -35,8 +35,6 @@ from beets.library import Item
 from beets.test import _common
 from beets.test.helper import (
     NEEDS_FFPROBE,
-    NEEDS_PY7ZR,
-    NEEDS_RARFILE,
     NEEDS_REFLINK,
     AsIsImporterMixin,
     AutotagImportHelper,
@@ -49,6 +47,7 @@ from beets.test.helper import (
     TerminalImportSessionFixture,
     TestHelper,
     has_program,
+    is_importable,
 )
 from beets.util import bytestring_path, syspath
 from beets.util.extension import remux_mpeglayer3_wav
@@ -258,13 +257,16 @@ class TestImportTar(TestImportZip):
         return path
 
 
-@NEEDS_RARFILE
+@pytest.mark.skipif(
+    not (is_importable("rarfile") and has_program("unrar")),
+    reason="rarfile or unrar program not found",
+)
 class TestImportRar(TestImportZip):
     def create_archive(self):
         return _common.RSRC / "archive.rar"
 
 
-@NEEDS_PY7ZR
+@pytest.mark.skipif(not is_importable("py7zr"), reason="py7zr is not available")
 class TestImport7z(TestImportZip):
     def create_archive(self):
         return _common.RSRC / "archive.7z"

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -35,6 +35,8 @@ from beets.library import Item
 from beets.test import _common
 from beets.test.helper import (
     NEEDS_FFPROBE,
+    NEEDS_PY7ZR,
+    NEEDS_RARFILE,
     NEEDS_REFLINK,
     AsIsImporterMixin,
     AutotagImportHelper,
@@ -256,12 +258,13 @@ class TestImportTar(TestImportZip):
         return path
 
 
-@pytest.mark.skipif(not has_program("unrar"), reason="unrar program not found")
+@NEEDS_RARFILE
 class TestImportRar(TestImportZip):
     def create_archive(self):
         return _common.RSRC / "archive.rar"
 
 
+@NEEDS_PY7ZR
 class TestImport7z(TestImportZip):
     def create_archive(self):
         return _common.RSRC / "archive.7z"


### PR DESCRIPTION
## Description

Fixes #7002.

Both `py7zr` and `rarfile` are optional dependencies specified under the `import` extra (`beets[import]`).
When running the test suite in environments where `py7zr` is not installed (e.g. minimal packaging buildroots such as Fedora Rawhide), `ArchiveImportTask.handlers` does not register the 7z extraction handler. Consequently, `TestImport7z` runs unconditionally and treats `archive.7z` as an ordinary file rather than an archive, failing with:
```text
FAILED test/test_importer.py::TestImport7z::test_import_zip
E       assert 0 == 1
E        +  where 0 = len(<beets.dbcore.db.Results object>)
E        +    where <beets.dbcore.db.Results object> = items()
WARNING beets:stages.py:58 No files imported from .../test/rsrc/archive.7z
```

Additionally, `TestImportRar` previously checked only for the presence of the `unrar` executable via `has_program("unrar")`, but extraction also depends on the Python `rarfile` package being importable.

This PR:
1. Adds `NEEDS_PY7ZR` (`is_importable("py7zr")`) and `NEEDS_RARFILE` (`is_importable("rarfile") and has_program("unrar")`) test skip markers in `beets.test.helper`.
2. Marks `TestImport7z` with `@NEEDS_PY7ZR`.
3. Marks `TestImportRar` with `@NEEDS_RARFILE`.
4. Adds an unreleased bug fix entry to `docs/changelog.rst`.

## To Do

- [x] ~Documentation.~
- [x] Changelog.
- [x] Tests.
