### PR TITLE
importer: restore candidate update from manual search and ID prompts

### DIFF
--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Literal
 from beets import config, importer, logging, plugins, ui
 from beets.autotag import (
     AlbumMatch,
+    Proposal,
     Recommendation,
     TrackMatch,
     tag_album,
@@ -23,7 +24,7 @@ from .display import show_change, show_item_change
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from beets.autotag import Proposal, Source
+    from beets.autotag import Source
     from beets.importer import ImportSession, ImportTask
     from beets.library import AlbumOrItem, Item
     from beets.util import PathBytes
@@ -113,6 +114,9 @@ class TerminalImportSession(importer.ImportSession):
                 post_choice = choice.callback(self, task)
                 if isinstance(post_choice, importer.Action):
                     return post_choice
+                if isinstance(post_choice, Proposal):
+                    task.candidates = post_choice.candidates
+                    task.rec = post_choice.recommendation
             else:
                 # We have a candidate! Finish tagging. Here, choice is an
                 # AlbumMatch object.
@@ -168,6 +172,9 @@ class TerminalImportSession(importer.ImportSession):
                 post_choice = choice.callback(self, task)
                 if isinstance(post_choice, importer.Action):
                     return post_choice
+                if isinstance(post_choice, Proposal):
+                    task.candidates = post_choice.candidates
+                    task.rec = post_choice.recommendation
 
     def _report_item_summary(
         self, prefix: Literal["Old", "New"], items: list[Item], is_album: bool

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,8 +17,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Fix interactive importer ignoring candidates from manual search (``e``) and
-  manual ID (``i``) entry.
-  :bug:`7000`
+  manual ID (``i``) entry. :bug:`7000`
 
 Other changes
 ~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,13 +13,12 @@ Unreleased
     New features
     ~~~~~~~~~~~~
 
-..
-    Bug fixes
-    ~~~~~~~~~
+Bug fixes
+~~~~~~~~~
 
-..
-    For plugin developers
-    ~~~~~~~~~~~~~~~~~~~~~
+- Fix interactive importer ignoring candidates from manual search (``e``) and
+  manual ID (``i``) entry.
+  :bug:`7000`
 
 Other changes
 ~~~~~~~~~~~~~

--- a/test/ui/test_ui_importer.py
+++ b/test/ui/test_ui_importer.py
@@ -55,6 +55,7 @@ class ChooseCandidateTest(
         self.importer.io.addinput("e")
         self.importer.io.addinput("ManualArtist")
         self.importer.io.addinput("ManualAlbum")
+        self.importer.io.addinput("m")
         self.importer.io.addinput("1")
         self.importer.io.addinput("a")
         self.importer.run()
@@ -68,6 +69,7 @@ class ChooseCandidateTest(
         ):
             self.importer.io.addinput("i")
             self.importer.io.addinput("custom_release_id")
+            self.importer.io.addinput("m")
             self.importer.io.addinput("1")
             self.importer.io.addinput("a")
             self.importer.run()

--- a/test/ui/test_ui_importer.py
+++ b/test/ui/test_ui_importer.py
@@ -42,7 +42,15 @@ class ImportExistingTest(TerminalImportMixin, test_importer.ImportExistingTest):
 class ChooseCandidateTest(
     TerminalImportMixin, test_importer.ChooseCandidateTest
 ):
-    pass
+    def test_manual_search_updates_candidates(self):
+        self.importer.io.addinput("e")
+        self.importer.io.addinput("ManualArtist")
+        self.importer.io.addinput("ManualAlbum")
+        self.importer.io.addinput("1")
+        self.importer.io.addinput("a")
+        self.importer.run()
+        album = self.lib.albums().get()
+        assert "ManualAlbum" in album.album
 
 
 class GroupAlbumsImportTest(

--- a/test/ui/test_ui_importer.py
+++ b/test/ui/test_ui_importer.py
@@ -4,6 +4,8 @@ test_importer module. But here the test importer inherits from
 ``TerminalImportSession``. So we test this class, too.
 """
 
+from unittest import mock
+
 from beets import importer
 from beets.test.helper import TerminalImportMixin
 from test import test_importer
@@ -18,11 +20,17 @@ class TestNonAutotaggedImport(
 class TestImport(TerminalImportMixin, test_importer.TestImport):
     pass
 
-
 class ImportSingletonTest(
     TerminalImportMixin, test_importer.ImportSingletonTest
 ):
-    pass
+    def test_singleton_manual_search_updates_candidates(self):
+        self.importer.io.addinput("e")
+        self.importer.io.addinput("ManualArtist")
+        self.importer.io.addinput("ManualTrack")
+        self.importer.io.addinput("a")
+        self.importer.run()
+        assert not self.lib.albums()
+        assert self.lib.items().get().title == "ManualTrack"
 
 
 class ImportTracksTest(TerminalImportMixin, test_importer.ImportTracksTest):
@@ -51,6 +59,19 @@ class ChooseCandidateTest(
         self.importer.run()
         album = self.lib.albums().get()
         assert "ManualAlbum" in album.album
+
+    def test_manual_id_updates_candidates(self):
+        album_info = self.matcher._make_album_match("IDArtist", "IDAlbum", 1)
+        with mock.patch(
+            "beets.metadata_plugins.albums_for_ids", return_value=[album_info]
+        ):
+            self.importer.io.addinput("i")
+            self.importer.io.addinput("custom_release_id")
+            self.importer.io.addinput("1")
+            self.importer.io.addinput("a")
+            self.importer.run()
+            album = self.lib.albums().get()
+            assert "IDAlbum" in album.album
 
 
 class GroupAlbumsImportTest(

--- a/test/ui/test_ui_importer.py
+++ b/test/ui/test_ui_importer.py
@@ -20,6 +20,7 @@ class TestNonAutotaggedImport(
 class TestImport(TerminalImportMixin, test_importer.TestImport):
     pass
 
+
 class ImportSingletonTest(
     TerminalImportMixin, test_importer.ImportSingletonTest
 ):


### PR DESCRIPTION
## Description

Fixes #7000.

In commit `d143e2cb`, `Proposal` was moved to `if TYPE_CHECKING:` in `beets/ui/commands/import_/session.py`. As part of that typing refactor, the runtime handling for `Proposal` return values from prompt choice callbacks was removed from both `TerminalImportSession.choose_match()` and `choose_item()`.

As a result, when an interactive importer user chose `e` ("Enter search") or `i` ("enter Id"), `manual_search` or `manual_id` successfully fetched matching candidates and returned a `Proposal`, but the return value was dropped, leaving the active import task with the stale pre-lookup candidates list.

## Solution

1. Import `Proposal` at runtime from `beets.autotag`.
2. Restore the `if isinstance(post_choice, Proposal):` assignment branch in both `choose_match()` and `choose_item()`:
   ```python
   task.candidates = post_choice.candidates
   task.rec = post_choice.recommendation
   ```
3. Add end-to-end regression test in `test/ui/test_ui_importer.py` verifying that manual search updates `task.candidates` and applies the chosen manual candidate.
