### PR TITLE
test: skip archive import tests when optional dependencies are missing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,9 @@ Other changes
   option: explain how the external command is run, remove the broken ``md5sum
   {file}`` example and show how to use such commands through a wrapper script.
   :bug:`3979`
+- Skip archive import tests (``TestImport7z`` and ``TestImportRar``) when
+  optional dependencies (``py7zr`` or ``rarfile``/``unrar``) are not available.
+  :bug:`7002`
 
 2.14.0 (September 07, 2026)
 ---------------------------

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -47,6 +47,7 @@ from beets.test.helper import (
     TerminalImportSessionFixture,
     TestHelper,
     has_program,
+    is_importable,
 )
 from beets.util import bytestring_path, syspath
 from beets.util.extension import remux_mpeglayer3_wav
@@ -256,12 +257,16 @@ class TestImportTar(TestImportZip):
         return path
 
 
-@pytest.mark.skipif(not has_program("unrar"), reason="unrar program not found")
+@pytest.mark.skipif(
+    not (is_importable("rarfile") and has_program("unrar")),
+    reason="rarfile or unrar not found",
+)
 class TestImportRar(TestImportZip):
     def create_archive(self):
         return _common.RSRC / "archive.rar"
 
 
+@pytest.mark.skipif(not is_importable("py7zr"), reason="py7zr not installed")
 class TestImport7z(TestImportZip):
     def create_archive(self):
         return _common.RSRC / "archive.7z"


### PR DESCRIPTION
## Description
Fixes #7002.

In minimal or distribution build environments (such as Fedora Rawhide package builds) where optional archive dependencies are not installed, archive import tests fail:
- `TestImport7z` ran unconditionally despite `py7zr` being an optional dependency. When `py7zr` is missing, `ArchiveImportTask.handlers` does not register the 7z handler, treating the test archive as an ordinary file and failing with `assert 0 == 1`.
- `TestImportRar` checked only for the `unrar` executable, but also requires the `rarfile` python module to be importable.

### Changes
- Skip `TestImport7z` when `not is_importable("py7zr")`.
- Skip `TestImportRar` when `not (is_importable("rarfile") and has_program("unrar"))`.
- Add changelog entry in `docs/changelog.rst`.
