### PR TITLE
fix(library): don't let an empty leading path field escape the base directory

### DIFF
--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1290,6 +1290,11 @@ class Item(LibModel):
                 "the filename.",
                 subpath,
             )
+        # The fragment is always relative to the base directory. Strip
+        # leading separators (left by empty leading template fields when
+        # the replacements do not remove them) which would otherwise make
+        # `os.path.join` discard `basedir`.
+        lib_path_str = lib_path_str.lstrip(os.sep + (os.altsep or ""))
         lib_path_bytes = util.bytestring_path(lib_path_str)
 
         if relative_to_libdir:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,9 +13,13 @@ Unreleased
     New features
     ~~~~~~~~~~~~
 
-..
-    Bug fixes
-    ~~~~~~~~~
+Bug fixes
+~~~~~~~~~
+
+- Empty leading path-format fields (e.g. from missing metadata) combined with a
+  custom ``replace`` configuration no longer produce an absolute destination
+  path that escapes the library or :doc:`plugins/convert` destination directory;
+  leading path separators are now stripped from the rendered path. :bug:`4889`
 
 ..
     For plugin developers

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -461,6 +461,20 @@ class TestDestination(PytestItemHelper):
         item_in_db.album = "bar"
         assert item_in_db.destination() == np("base/ber/foo")
 
+    def test_destination_stays_in_basedir_with_empty_leading_field(
+        self, item_in_db
+    ):
+        # Regression test for #4889: an empty leading template field
+        # combined with custom replacements that lack the default
+        # separator rule must not produce an absolute path that escapes
+        # the base directory.
+        self.lib.directory = b"base"
+        self.lib.replacements = [(re.compile(r"a"), "e")]
+        self.lib.path_formats = [("default", "$album/$title")]
+        item_in_db.album = ""
+        item_in_db.title = "three"
+        assert item_in_db.destination() == np("base/three")
+
     @unittest.skip("unimplemented: #359")
     def test_destination_with_empty_component(self, item_in_db):
         self.lib.directory = b"base"


### PR DESCRIPTION
## Description

Fixes #4889.

When the first field of a path format is empty, the rendered fragment starts with a separator (the reporter's untagged files gave `//00 ` from the default path format). `util.components()` keeps that leading separator as a root component. The default `replace` rules turn it into `_`, but a custom `replace` config overrides the defaults, so the root survives, the fragment comes back absolute and `os.path.join(basedir, ...)` throws the base directory away. With convert's `auto: yes` that ended in:

```text
PermissionError: [Errno 13] Permission denied: b'//00 .mp3'
```

The fragment is always meant to be relative to the base directory, so `Item.destination()` now strips leading separators before joining. Nothing changes for the default replacements. Added a regression test next to `test_destination_with_replacements`. It fails on master and passes with the change.

## To Do

- [x] ~Documentation.~ Bug fix, no new options.
- [x] Changelog.
- [x] Tests.
