### PR TITLE
autotag: skip automatic online candidate search when artist and album/title are empty

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -449,7 +449,9 @@ def tag_album(
             ):
                 _add_candidate(source, candidates, matched_candidate)
         else:
-            log.debug("Skipping album candidate search: no artist or album name.")
+            log.debug(
+                "Skipping album candidate search: no artist or album name."
+            )
 
     log.debug("Evaluating {} candidates.", len(candidates))
     # Sort and get the recommendation.

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -434,15 +434,22 @@ def tag_album(
             search_artist, search_name = source.artist, source.name
         log.debug("Search terms: {} - {}", search_artist, search_name)
 
-        # Is this album likely to be a "various artist" release?
-        va_likely = source.va_likely or (search_artist.lower() in VA_ARTISTS)
-        log.debug("Album might be VA: {}", va_likely)
+        # Skip candidate search if both artist and album name are empty,
+        # avoiding useless and slow search queries on un-tagged files (#4640).
+        if search_artist or search_name:
+            # Is this album likely to be a "various artist" release?
+            va_likely = source.va_likely or (
+                search_artist.lower() in VA_ARTISTS
+            )
+            log.debug("Album might be VA: {}", va_likely)
 
-        # Get the results from the data sources.
-        for matched_candidate in metadata_plugins.candidates(
-            source.items, search_artist, search_name, va_likely
-        ):
-            _add_candidate(source, candidates, matched_candidate)
+            # Get the results from the data sources.
+            for matched_candidate in metadata_plugins.candidates(
+                source.items, search_artist, search_name, va_likely
+            ):
+                _add_candidate(source, candidates, matched_candidate)
+        else:
+            log.debug("Skipping album candidate search: no artist or album name.")
 
     log.debug("Evaluating {} candidates.", len(candidates))
     # Sort and get the recommendation.
@@ -497,11 +504,16 @@ def tag_item(
     log.debug("Item search terms: {} - {}", search_artist, search_name)
 
     # Get and evaluate candidate metadata.
-    for track_info in metadata_plugins.item_candidates(
-        item, search_artist, search_name
-    ):
-        dist = track_distance(item, track_info, incl_artist=True)
-        candidates[track_info.identifier] = TrackMatch(dist, track_info, item)
+    if search_artist or search_name:
+        for track_info in metadata_plugins.item_candidates(
+            item, search_artist, search_name
+        ):
+            dist = track_distance(item, track_info, incl_artist=True)
+            candidates[track_info.identifier] = TrackMatch(
+                dist, track_info, item
+            )
+    else:
+        log.debug("Skipping track candidate search: no artist or track title.")
 
     # Sort by distance and return with recommendation.
     log.debug("Found {} candidates.", len(candidates))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,13 +13,11 @@ Unreleased
     New features
     ~~~~~~~~~~~~
 
-..
-    Bug fixes
-    ~~~~~~~~~
+Bug fixes
+~~~~~~~~~
 
-..
-    For plugin developers
-    ~~~~~~~~~~~~~~~~~~~~~
+- Skip automatic online metadata candidate search during import when both
+  artist and album/title metadata are empty. :bug:`4640`
 
 Other changes
 ~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,8 +16,8 @@ Unreleased
 Bug fixes
 ~~~~~~~~~
 
-- Skip automatic online metadata candidate search during import when both
-  artist and album/title metadata are empty. :bug:`4640`
+- Skip automatic online metadata candidate search during import when both artist
+  and album/title metadata are empty. :bug:`4640`
 
 Other changes
 ~~~~~~~~~~~~~

--- a/test/autotag/test_match.py
+++ b/test/autotag/test_match.py
@@ -194,3 +194,19 @@ class TestTagMultipleDataSources:
         proposal = tag_item(source)
 
         self.check_proposal(proposal)
+
+    def test_search_album_empty_metadata_skips_candidates(self):
+        source = Source.from_items([Item()])
+
+        proposal = tag_album(source)
+
+        assert len(proposal.candidates) == 0
+        assert proposal.recommendation.name == "none"
+
+    def test_search_track_empty_metadata_skips_candidates(self):
+        source = Source.from_item(Item())
+
+        proposal = tag_item(source)
+
+        assert len(proposal.candidates) == 0
+        assert proposal.recommendation.name == "none"


### PR DESCRIPTION
## Description

Fixes #4640.

When importing untagged tracks or directories where both artist and album (or track title in singleton mode) metadata are empty (e.g. `Finding tags for album " - "`), beets previously proceeded to query all enabled metadata plugins with empty search terms. This caused:
1. Slow network requests across multiple online metadata providers (MusicBrainz, Discogs, Beatport, Deezer, etc.).
2. Low-confidence, irrelevant search candidate proposals shown to the user.

This change checks whether either `search_artist` or `search_name` is non-empty before initiating the plugin candidate query in `tag_album` and `tag_item`. If both are empty and no explicit candidate IDs are present, it skips the search early, logs a debug message, and returns an empty proposal with `Recommendation.none`.

Manual search (`manual_search`, `manual_id`) remains completely unaffected as it takes explicit user input.

## To Do

- [x] ~Documentation.~
- [x] Changelog.
- [x] Tests.
