### PR TITLE
docs: add beets-genrecanon to external plugins

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -507,7 +507,7 @@ beets-getlrc_
 
 beets-genrecanon_
     Maps existing genres into a separate, user-defined canonical taxonomy while
-    preserving the original genre metadata.    
+    preserving the original genre metadata.
 
 beets-goingrunning_
     Generates playlists to go with your running sessions.

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -501,13 +501,13 @@ beetFs_
     Is a FUSE filesystem for browsing the music in your beets library. (Might be
     out of date.)
 
-beets-getlrc_
-    Fetches synced and non-synced lyrics and creates .lrc files to be used by
-    compatible music players.
-
 beets-genrecanon_
     Maps existing genres into a separate, user-defined canonical taxonomy while
     preserving the original genre metadata.
+
+beets-getlrc_
+    Fetches synced and non-synced lyrics and creates .lrc files to be used by
+    compatible music players.
 
 beets-goingrunning_
     Generates playlists to go with your running sessions.
@@ -629,9 +629,9 @@ beets-youtube_
 
 .. _beets-follow: https://github.com/nolsto/beets-follow
 
-.. _beets-getlrc: https://github.com/jaedonswanson/beets-getlrc
-
 .. _beets-genrecanon: https://codeberg.org/gbcox/beets-genrecanon
+
+.. _beets-getlrc: https://github.com/jaedonswanson/beets-getlrc
 
 .. _beets-goingrunning: https://pypi.org/project/beets-goingrunning
 

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -505,6 +505,10 @@ beets-getlrc_
     Fetches synced and non-synced lyrics and creates .lrc files to be used by
     compatible music players.
 
+beets-genrecanon_
+    Maps existing genres into a separate, user-defined canonical taxonomy
+    while preserving the original genre metadata.
+
 beets-goingrunning_
     Generates playlists to go with your running sessions.
 
@@ -626,6 +630,8 @@ beets-youtube_
 .. _beets-follow: https://github.com/nolsto/beets-follow
 
 .. _beets-getlrc: https://github.com/jaedonswanson/beets-getlrc
+
+.. _beets-genrecanon: https://codeberg.org/gbcox/beets-genrecanon
 
 .. _beets-goingrunning: https://pypi.org/project/beets-goingrunning
 

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -506,8 +506,8 @@ beets-getlrc_
     compatible music players.
 
 beets-genrecanon_
-    Maps existing genres into a separate, user-defined canonical taxonomy
-    while preserving the original genre metadata.
+    Maps existing genres into a separate, user-defined canonical taxonomy while
+    preserving the original genre metadata.    
 
 beets-goingrunning_
     Generates playlists to go with your running sessions.


### PR DESCRIPTION
Adds `beets-genrecanon` to the external plugins list.

The plugin maps existing genre metadata into a separate, user-defined
`genre_canon` field and `GENRE_CANON` file tag while preserving the original
genre.

Project: https://codeberg.org/gbcox/beets-genrecanon  
PyPI: https://pypi.org/project/beets-genrecanon/
