### PR TITLE
util: store authentication token files with 0600 permissions

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -16,8 +16,8 @@ import tempfile
 import traceback
 import unicodedata
 from collections import Counter
-from collections.abc import Sequence
-from contextlib import suppress
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager, suppress
 from copy import deepcopy
 from enum import Enum
 from functools import cache, cached_property
@@ -632,6 +632,56 @@ def reflink(
         raise FilesystemError(
             msg, "reflink", (path, dest), traceback.format_exc()
         ) from exc
+
+
+@contextmanager
+def open_private(
+    path: PathLike, mode: str = "w", encoding: str | None = "utf-8"
+) -> Iterator[Any]:
+    """Open a file with 0600 permissions (read/write by owner only).
+
+    When creating a file, it is created with 0600 permissions atomically.
+    On existing files, permissions are restricted to 0600.
+    """
+    sys_path = syspath(path)
+    parent_dir = os.path.dirname(sys_path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+
+    if "+" in mode:
+        flags = os.O_CREAT | os.O_RDWR
+    else:
+        flags = os.O_CREAT | os.O_WRONLY
+    if "a" in mode:
+        flags |= os.O_APPEND
+    else:
+        flags |= os.O_TRUNC
+
+    fd = os.open(sys_path, flags, 0o600)
+    with suppress(OSError):
+        os.chmod(sys_path, 0o600)
+
+    try:
+        if "b" in mode:
+            f = open(fd, mode)
+        else:
+            f = open(fd, mode, encoding=encoding)
+    except Exception:
+        os.close(fd)
+        raise
+
+    try:
+        yield f
+    finally:
+        f.close()
+
+
+def restrict_permissions(path: PathLike) -> None:
+    """Ensure a sensitive file (such as a token file) has 0600 permissions."""
+    sys_path = syspath(path)
+    if os.path.exists(sys_path):
+        with suppress(OSError):
+            os.chmod(sys_path, 0o600)
 
 
 def unique_path(path: AnyStr) -> AnyStr:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -643,25 +643,38 @@ def open_private(
     When creating a file, it is created with 0600 permissions atomically.
     On existing files, permissions are restricted to 0600.
     """
+    text_mode = mode.replace("b", "")
+    if text_mode == "r":
+        flags = os.O_RDONLY
+    elif text_mode == "r+":
+        flags = os.O_RDWR
+    elif text_mode == "w":
+        flags = os.O_CREAT | os.O_TRUNC | os.O_WRONLY
+    elif text_mode == "w+":
+        flags = os.O_CREAT | os.O_TRUNC | os.O_RDWR
+    elif text_mode == "a":
+        flags = os.O_CREAT | os.O_APPEND | os.O_WRONLY
+    elif text_mode == "a+":
+        flags = os.O_CREAT | os.O_APPEND | os.O_RDWR
+    elif text_mode == "x":
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    elif text_mode == "x+":
+        flags = os.O_CREAT | os.O_EXCL | os.O_RDWR
+    else:
+        raise ValueError(f"Invalid mode: {mode!r}")
+
     sys_path = syspath(path)
     parent_dir = os.path.dirname(sys_path)
     if parent_dir:
         os.makedirs(parent_dir, exist_ok=True)
 
-    if "+" in mode:
-        flags = os.O_CREAT | os.O_RDWR
-    else:
-        flags = os.O_CREAT | os.O_WRONLY
-    if "a" in mode:
-        flags |= os.O_APPEND
-    else:
-        flags |= os.O_TRUNC
-
     fd = os.open(sys_path, flags, 0o600)
-    with suppress(OSError):
-        os.chmod(sys_path, 0o600)
-
     try:
+        try:
+            os.chmod(sys_path, 0o600)
+        except (NotImplementedError, FileNotFoundError):
+            pass
+
         if "b" in mode:
             f = open(fd, mode)
         else:
@@ -679,9 +692,10 @@ def open_private(
 def restrict_permissions(path: PathLike) -> None:
     """Ensure a sensitive file (such as a token file) has 0600 permissions."""
     sys_path = syspath(path)
-    if os.path.exists(sys_path):
-        with suppress(OSError):
-            os.chmod(sys_path, 0o600)
+    try:
+        os.chmod(sys_path, 0o600)
+    except (FileNotFoundError, NotImplementedError):
+        pass
 
 
 def unique_path(path: AnyStr) -> AnyStr:

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -21,7 +21,7 @@ from beets import config
 from beets.autotag import AlbumInfo, TrackInfo
 from beets.exceptions import UserError
 from beets.metadata_plugins import MetadataSourcePlugin
-from beets.util import unique_list
+from beets.util import open_private, restrict_permissions, unique_list
 from beets.util.deprecation import deprecate_for_user
 
 if TYPE_CHECKING:
@@ -327,7 +327,9 @@ class BeatportPlugin(MetadataSourcePlugin):
 
         # Get the OAuth token from a file or log in.
         try:
-            with open(self._tokenfile()) as f:
+            tokenfile = self._tokenfile()
+            restrict_permissions(tokenfile)
+            with open(tokenfile) as f:
                 tokendata = json.load(f)
         except OSError:
             # No token yet. Generate one.
@@ -360,7 +362,7 @@ class BeatportPlugin(MetadataSourcePlugin):
 
         # Save the token for later use.
         self._log.debug("Beatport token {}, secret {}", token, secret)
-        with open(self._tokenfile(), "w") as f:
+        with open_private(self._tokenfile(), "w") as f:
             json.dump({"token": token, "secret": secret}, f)
 
         return token, secret

--- a/beetsplug/discogs/__init__.py
+++ b/beetsplug/discogs/__init__.py
@@ -139,7 +139,9 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
 
         # Get the OAuth token from a file or log in.
         try:
-            with open(self._tokenfile()) as f:
+            tokenfile = self._tokenfile()
+            util.restrict_permissions(tokenfile)
+            with open(tokenfile) as f:
                 tokendata = json.load(f)
         except OSError:
             # No token yet. Generate one.
@@ -183,7 +185,7 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
 
         # Save the token for later use.
         self._log.debug("Discogs token {}, secret {}", token, secret)
-        with open(self._tokenfile(), "w") as f:
+        with util.open_private(self._tokenfile(), "w") as f:
             json.dump({"token": token, "secret": secret}, f)
 
         return token, secret

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -30,6 +30,7 @@ from beets import __version__, ui
 from beets.exceptions import UserError
 from beets.logging import getLogger
 from beets.plugins import BeetsPlugin
+from beets.util import open_private, restrict_permissions
 from beetsplug._utils.requests import (
     BeetsHTTPError,
     RequestHandler,
@@ -119,6 +120,7 @@ class PlexSession(TimeoutAndRetrySession):
         """
         if self._token_cache is None:
             with suppress(FileNotFoundError, JSONDecodeError, OSError):
+                restrict_permissions(self.token_path)
                 self._token_cache = json.loads(self.token_path.read_text())
 
         return self._token_cache or {}
@@ -127,7 +129,8 @@ class PlexSession(TimeoutAndRetrySession):
         """Merge data into the token file and persist it."""
         token = self.load_token()
         token.update(data)
-        self.token_path.write_text(json.dumps(token, indent=2))
+        with open_private(self.token_path, "w") as f:
+            json.dump(token, f, indent=2)
 
     def request(self, *args, **kwargs) -> requests.Response:
         """Send a request, attaching the auth token."""

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -24,7 +24,7 @@ from beets.dbcore import types
 from beets.exceptions import UserError
 from beets.library import Library
 from beets.metadata_plugins import IDResponse, SearchApiMetadataSourcePlugin
-from beets.util import chunks
+from beets.util import chunks, open_private, restrict_permissions
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -180,7 +180,9 @@ class SpotifyPlugin(
         """Retrieve previously saved OAuth token or generate a new one."""
 
         try:
-            with open(self._tokenfile()) as f:
+            tokenfile = self._tokenfile()
+            restrict_permissions(tokenfile)
+            with open(tokenfile) as f:
                 token_data = json.load(f)
         except OSError:
             self._authenticate()
@@ -218,7 +220,7 @@ class SpotifyPlugin(
 
         # Save the token for later use.
         self._log.debug("{0.data_source} access token: {0.access_token}", self)
-        with open(self._tokenfile(), "w") as f:
+        with open_private(self._tokenfile(), "w") as f:
             json.dump({"access_token": self.access_token}, f)
 
     def _handle_response(

--- a/beetsplug/tidal/session.py
+++ b/beetsplug/tidal/session.py
@@ -11,6 +11,7 @@ from requests_oauthlib import OAuth2Session
 from urllib3.util.retry import Retry
 
 from beets.logging import getLogger
+from beets.util import open_private, restrict_permissions
 from beetsplug._utils.requests import RateLimitAdapter, TimeoutAndRetrySession
 
 if TYPE_CHECKING:
@@ -69,13 +70,14 @@ class TidalSession(OAuth2Session, TimeoutAndRetrySession):
     def load_token(self) -> JSONDict | None:
         """Load token from JSON file."""
         if self.token_path.exists():
+            restrict_permissions(self.token_path)
             with open(self.token_path) as f:
                 return json.load(f)
         return None
 
     def save_token(self, token: JSONDict) -> None:
         """Save token to JSON file."""
-        with open(self.token_path, "w") as f:
+        with open_private(self.token_path, "w") as f:
             json.dump(token, f, indent=2)
 
     def request(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,9 +13,12 @@ Unreleased
     New features
     ~~~~~~~~~~~~
 
-..
-    Bug fixes
-    ~~~~~~~~~
+Bug fixes
+~~~~~~~~~
+
+- Store authentication token files (Beatport, Discogs, Plex, Spotify, Tidal)
+  with ``0600`` permissions and restrict existing token files to owner
+  read/write. :bug:`6984`
 
 ..
     For plugin developers

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -575,3 +575,29 @@ class PrivateFilesTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = os.path.join(temp_dir, "nonexistent.json")
             util.restrict_permissions(path)
+
+    def test_open_private_chmod_failure_raises_and_closes_fd(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "token.json")
+            with patch("os.chmod", side_effect=PermissionError("Chmod denied")):
+                with pytest.raises(PermissionError):
+                    with util.open_private(path, "w") as f:
+                        f.write("secret")
+
+    def test_restrict_permissions_chmod_failure_raises(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "token.json")
+            with open(path, "w") as f:
+                f.write("data")
+            with patch("os.chmod", side_effect=PermissionError("Chmod denied")):
+                with pytest.raises(PermissionError):
+                    util.restrict_permissions(path)
+
+    def test_open_private_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="Invalid mode"):
+            with util.open_private("dummy", "invalid"):
+                pass

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -514,3 +514,64 @@ class EditorCommandTest(unittest.TestCase):
         """Falls back to $EDITOR when no editor config or $VISUAL is set."""
         with patch.dict(os.environ, {"EDITOR": "emacs"}, clear=True):
             assert util.editor_command() == "emacs"
+
+
+class PrivateFilesTest(unittest.TestCase):
+    def test_open_private_creates_file(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "sub", "token.json")
+            with util.open_private(path, "w") as f:
+                f.write("secret_data")
+
+            with open(path) as f:
+                assert f.read() == "secret_data"
+
+            if platform.system() != "Windows":
+                assert (os.stat(path).st_mode & 0o777) == 0o600
+
+    def test_open_private_binary(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "token.bin")
+            with util.open_private(path, "wb") as f:
+                f.write(b"binary_secret")
+
+            with open(path, "rb") as f:
+                assert f.read() == b"binary_secret"
+
+    def test_open_private_calls_chmod(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "token.json")
+            with patch("os.chmod") as mock_chmod:
+                with util.open_private(path, "w") as f:
+                    f.write("test")
+                mock_chmod.assert_called_once_with(util.syspath(path), 0o600)
+
+    def test_restrict_permissions(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "token.json")
+            with open(path, "w") as f:
+                f.write("data")
+
+            with patch("os.chmod") as mock_chmod:
+                util.restrict_permissions(path)
+                mock_chmod.assert_called_once_with(util.syspath(path), 0o600)
+
+            if platform.system() != "Windows":
+                os.chmod(path, 0o644)
+                util.restrict_permissions(path)
+                assert (os.stat(path).st_mode & 0o777) == 0o600
+
+    def test_restrict_permissions_nonexistent(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "nonexistent.json")
+            util.restrict_permissions(path)


### PR DESCRIPTION
## Description

Fixes #6984.

This PR introduces `open_private` and `restrict_permissions` in `beets.util` to ensure sensitive token files are stored with `0600` permissions (owner read/write only).

Changes:
- Add `open_private` context manager to atomically create files with `0600` mode, and `restrict_permissions` helper to restrict existing files.
- Apply restricted permissions across plugins storing authentication tokens: `beatport`, `discogs`, `plexupdate`, `spotify`, and `tidal`.
- Add unit tests for `open_private` and `restrict_permissions` in `test/test_util.py`.

## To Do

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
