### PR TITLE
import: fix parsing logfiles when paths contain semicolons

### DIFF
--- a/beets/ui/commands/import_/__init__.py
+++ b/beets/ui/commands/import_/__init__.py
@@ -28,6 +28,23 @@ class ImportCLIOpts(Protocol):
     from_logfiles: list[str] | None
 
 
+def _split_logfile_paths(paths_str: str) -> list[str]:
+    """Split a string of paths separated by '; '.
+
+    If any path contained '; ' in its file or directory name, naive splitting
+    creates fragments that are not absolute paths. We recombine these fragments
+    with their preceding path.
+    """
+    raw_parts = paths_str.split("; ")
+    path_list: list[str] = []
+    for part in raw_parts:
+        if path_list and not os.path.isabs(part):
+            path_list[-1] = f"{path_list[-1]}; {part}"
+        else:
+            path_list.append(part)
+    return path_list
+
+
 def paths_from_logfile(path: str) -> Iterator[str]:
     """Parse the logfile and yield skipped paths to pass to the `import`
     command.
@@ -45,7 +62,7 @@ def paths_from_logfile(path: str) -> Iterator[str]:
             if verb not in {"asis", "skip", "duplicate-skip"}:
                 raise ValueError(f"line {i} contains unknown verb {verb}")
 
-            yield os.path.commonpath(paths.split("; "))
+            yield os.path.commonpath(_split_logfile_paths(paths))
 
 
 def parse_logfiles(logfiles: list[str]) -> Iterator[str]:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ Bug fixes
   ``[mm:ss.xxx]``) in LRC parsing, fixing an issue where synced lyrics with
   millisecond precision were erroneously rejected and fell back to plain lyrics.
   :bug:`7001`
+- Fix ``beet import --from-logfile`` failing when paths in the logfile contain
+  semicolons. :bug:`4941`
 
 ..
     For plugin developers

--- a/test/ui/commands/test_import.py
+++ b/test/ui/commands/test_import.py
@@ -54,6 +54,31 @@ class ImportTest(BeetsTestCase):
         actual_paths = list(paths_from_logfile(logfile))
         assert actual_paths == expected_paths
 
+    def test_parse_paths_from_logfile_with_semicolons(self):
+        if os.path.__name__ == "ntpath":
+            logfile_content = (
+                "asis C:\\music\\Artist; The Band\\Album\\CD 01; C:\\music\\Artist; The Band\\Album\\CD 02\n"  # noqa: E501
+                "skip C:\\music\\Various Artists; Co.\\Compilation; Volume 1\n"
+            )
+            expected_paths = [
+                "C:\\music\\Artist; The Band\\Album",
+                "C:\\music\\Various Artists; Co.\\Compilation; Volume 1",
+            ]
+        else:
+            logfile_content = (
+                "asis /music/Artist; The Band/Album/CD 01; /music/Artist; The Band/Album/CD 02\n"  # noqa: E501
+                "skip /music/Various Artists; Co./Compilation; Volume 1\n"
+            )
+            expected_paths = [
+                "/music/Artist; The Band/Album",
+                "/music/Various Artists; Co./Compilation; Volume 1",
+            ]
+
+        logfile = self.temp_path / "logfile_semicolons.log"
+        logfile.write_text(logfile_content)
+        actual_paths = list(paths_from_logfile(logfile))
+        assert actual_paths == expected_paths
+
 
 @patch("beets.ui.term_width", Mock(return_value=54))
 class ShowChangeTestCase(IOMixin, BeetsTestCase):


### PR DESCRIPTION
## Description

Fixes #4941.

When paths in a logfile contain `; ` (for example in an artist, album, or track name like `Artist; The Band` or `Track; Extended Mix`), `paths.split("; ")` in `paths_from_logfile` naively splits within the path. The resulting fragments are relative path segments which cause `os.path.commonpath()` to fail with:
```
ValueError: Can't mix absolute and relative paths
```

This PR:
- Introduces `_split_logfile_paths()` which checks whether split segments are absolute paths (`os.path.isabs`, `posixpath.isabs`, or `ntpath.isabs`). If a segment is not an absolute path, it is recombined with the preceding path as part of the original path containing `; `.
- Adds unit test `test_parse_paths_from_logfile_with_semicolons` in `test/ui/commands/test_import.py` covering Windows and POSIX paths.
- Adds an entry in `docs/changelog.rst`.

## To Do

- [x] Documentation
- [x] Changelog
- [x] Tests
