### PR TITLE
Fix importer UI displaying canonical artist instead of artist credit when enabled

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -122,6 +122,13 @@ class Info(AttrDict[Any]):
     def name(self) -> str:
         raise NotImplementedError
 
+    @property
+    def display_artist(self) -> str:
+        """Return the artist name to display, respecting the artist_credit config."""
+        if config["artist_credit"]:
+            return self.artist_credit or self.artist or ""
+        return self.artist or ""
+
     @cached_property
     def raw_data(self) -> JSONDict:
         """Provide metadata with artist credits applied when configured."""

--- a/beets/ui/commands/import_/display.py
+++ b/beets/ui/commands/import_/display.py
@@ -77,7 +77,7 @@ class ChangeRepresentation:
         parts.append(
             ui.colorize(
                 self.match.distance.color,
-                f"{self.match.info.artist} - {self.match.info.name}",
+                f"{self.match.info.display_artist} - {self.match.info.name}",
             )
         )
 
@@ -101,9 +101,12 @@ class ChangeRepresentation:
         # Artist.
         artist_l, artist_r = (
             self.original_artist,
-            self.match.info.artist or "",
+            self.match.info.display_artist,
         )
-        if artist_r == VARIOUS_ARTISTS:
+        if (
+            self.match.info.artist == VARIOUS_ARTISTS
+            or artist_r == VARIOUS_ARTISTS
+        ):
             # Hide artists for VA releases.
             artist_l, artist_r = "", ""
         if artist_l != artist_r:

--- a/beets/ui/commands/import_/display.py
+++ b/beets/ui/commands/import_/display.py
@@ -103,10 +103,7 @@ class ChangeRepresentation:
             self.original_artist,
             self.match.info.display_artist,
         )
-        if (
-            self.match.info.artist == VARIOUS_ARTISTS
-            or artist_r == VARIOUS_ARTISTS
-        ):
+        if artist_r == VARIOUS_ARTISTS:
             # Hide artists for VA releases.
             artist_l, artist_r = "", ""
         if artist_l != artist_r:

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -456,7 +456,7 @@ def choose_candidate(
                     match.distance.string,
                     colorize(
                         dist_color if i == 0 else "text_highlight_minor",
-                        f"{match.info.artist} - {match.info.name}",
+                        f"{match.info.display_artist} - {match.info.name}",
                     ),
                 ]
                 ui.print_(f"  {' '.join(line_parts)}")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,9 @@ Bug fixes
   ``[mm:ss.xxx]``) in LRC parsing, fixing an issue where synced lyrics with
   millisecond precision were erroneously rejected and fell back to plain lyrics.
   :bug:`7001`
+- Fix the importer UI displaying canonical artist names instead of artist credits
+  when :ref:`artist_credit` is enabled.
+  :bug:`5010`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,9 +20,8 @@ Bug fixes
   ``[mm:ss.xxx]``) in LRC parsing, fixing an issue where synced lyrics with
   millisecond precision were erroneously rejected and fell back to plain lyrics.
   :bug:`7001`
-- Fix the importer UI displaying canonical artist names instead of artist credits
-  when :ref:`artist_credit` is enabled.
-  :bug:`5010`
+- Fix the importer UI displaying canonical artist names instead of artist
+  credits when :ref:`artist_credit` is enabled. :bug:`5010`
 
 ..
     For plugin developers

--- a/test/autotag/test_hooks.py
+++ b/test/autotag/test_hooks.py
@@ -494,37 +494,49 @@ class TestAttrDictCachedPropertyMasking:
         assert obj.title == "ok"
 
 
-class DisplayArtistTest(BeetsTestCase):
-    def test_display_artist_disabled(self):
-        self.config["artist_credit"] = False
+class TestDisplayArtist:
+    @pytest.mark.parametrize(
+        "artist_credit_enabled, artist_credit, expected",
+        [
+            _p(False, "Credited Artist", "Canonical Artist", id="disabled"),
+            _p(True, "Credited Artist", "Credited Artist", id="enabled"),
+            _p(True, None, "Canonical Artist", id="fallback_none"),
+        ],
+    )
+    def test_album_display_artist(
+        self, config, artist_credit_enabled, artist_credit, expected
+    ):
+        config["artist_credit"] = artist_credit_enabled
         info = AlbumInfo(
-            artist="Canonical Artist",
-            artist_credit="Credited Artist",
-            tracks=[],
+            artist="Canonical Artist", artist_credit=artist_credit, tracks=[]
         )
-        assert info.display_artist == "Canonical Artist"
+        assert info.display_artist == expected
 
-    def test_display_artist_enabled(self):
-        self.config["artist_credit"] = True
-        info = AlbumInfo(
-            artist="Canonical Artist",
-            artist_credit="Credited Artist",
-            tracks=[],
-        )
-        assert info.display_artist == "Credited Artist"
-
-    def test_display_artist_enabled_fallback(self):
-        self.config["artist_credit"] = True
-        info = AlbumInfo(
-            artist="Canonical Artist", artist_credit=None, tracks=[]
-        )
-        assert info.display_artist == "Canonical Artist"
-
-    def test_track_display_artist(self):
-        self.config["artist_credit"] = True
+    @pytest.mark.parametrize(
+        "artist_credit_enabled, artist_credit, expected",
+        [
+            _p(
+                False,
+                "Credited Track Artist",
+                "Canonical Track Artist",
+                id="disabled",
+            ),
+            _p(
+                True,
+                "Credited Track Artist",
+                "Credited Track Artist",
+                id="enabled",
+            ),
+            _p(True, None, "Canonical Track Artist", id="fallback_none"),
+        ],
+    )
+    def test_track_display_artist(
+        self, config, artist_credit_enabled, artist_credit, expected
+    ):
+        config["artist_credit"] = artist_credit_enabled
         track = TrackInfo(
             title="A Track",
             artist="Canonical Track Artist",
-            artist_credit="Credited Track Artist",
+            artist_credit=artist_credit,
         )
-        assert track.display_artist == "Credited Track Artist"
+        assert track.display_artist == expected

--- a/test/autotag/test_hooks.py
+++ b/test/autotag/test_hooks.py
@@ -492,3 +492,39 @@ class TestAttrDictCachedPropertyMasking:
     def test_existing_dict_key_returns_value(self):
         obj = AttrDict[str]({"title": "ok"})
         assert obj.title == "ok"
+
+
+class DisplayArtistTest(BeetsTestCase):
+    def test_display_artist_disabled(self):
+        self.config["artist_credit"] = False
+        info = AlbumInfo(
+            artist="Canonical Artist",
+            artist_credit="Credited Artist",
+            tracks=[],
+        )
+        assert info.display_artist == "Canonical Artist"
+
+    def test_display_artist_enabled(self):
+        self.config["artist_credit"] = True
+        info = AlbumInfo(
+            artist="Canonical Artist",
+            artist_credit="Credited Artist",
+            tracks=[],
+        )
+        assert info.display_artist == "Credited Artist"
+
+    def test_display_artist_enabled_fallback(self):
+        self.config["artist_credit"] = True
+        info = AlbumInfo(
+            artist="Canonical Artist", artist_credit=None, tracks=[]
+        )
+        assert info.display_artist == "Canonical Artist"
+
+    def test_track_display_artist(self):
+        self.config["artist_credit"] = True
+        track = TrackInfo(
+            title="A Track",
+            artist="Canonical Track Artist",
+            artist_credit="Credited Track Artist",
+        )
+        assert track.display_artist == "Credited Track Artist"

--- a/test/ui/commands/test_import.py
+++ b/test/ui/commands/test_import.py
@@ -7,7 +7,6 @@ import pytest
 from beets import config, library
 from beets.autotag import AlbumInfo, AlbumMatch, Source, TrackInfo, distance
 from beets.exceptions import UserError
-from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 from beets.ui.commands.import_ import paths_from_logfile
 from beets.ui.commands.import_.display import show_change
@@ -57,14 +56,18 @@ class ImportTest(BeetsTestCase):
 
 @patch("beets.ui.term_width", Mock(return_value=54))
 class ShowChangeTestCase(IOMixin, BeetsTestCase):
-    def _show_change(self):
+    def _show_change(self, artist_credit: str | None = None):
         """Return an unicode string representing the changes"""
         long_name = f"a{' very' * 10} long name"
         album = "another album"
         albumartist = f"another artist with {long_name}"
 
         def make_item(**kwargs):
-            return _common.item(album=album, albumartist=albumartist, **kwargs)
+            item = library.Item(
+                album=album, albumartist=albumartist, length=60, format="F"
+            )
+            item.update(kwargs)
+            return item
 
         items = [
             make_item(track=1, title="first title"),
@@ -76,6 +79,7 @@ class ShowChangeTestCase(IOMixin, BeetsTestCase):
             album="caf\xe9",
             album_id="album id",
             artist="the artist",
+            artist_credit=artist_credit,
             artist_id="artist id",
             tracks=[
                 TrackInfo(title="first title", index=1),
@@ -150,6 +154,13 @@ class ShowChangeTestCase(IOMixin, BeetsTestCase):
             long name                              
 """  # noqa: W291
         )
+
+    def test_show_change_respects_artist_credit(self):
+        self.config["ui"]["import"]["layout"] = "newline"
+        self.config["artist_credit"] = True
+        msg = self._show_change(artist_credit="credited artist")
+        assert "credited artist - café" in msg
+        assert "-> credited artist" in msg
 
 
 @patch("beets.library.Item.try_filesize", Mock(return_value=987))

--- a/test/ui/commands/test_import.py
+++ b/test/ui/commands/test_import.py
@@ -5,12 +5,21 @@ from unittest.mock import Mock, patch
 import pytest
 
 from beets import config, library
-from beets.autotag import AlbumInfo, AlbumMatch, Source, TrackInfo, distance
+from beets.autotag import (
+    AlbumInfo,
+    AlbumMatch,
+    Recommendation,
+    Source,
+    TrackInfo,
+    distance,
+)
+from beets.autotag.distance import Distance
 from beets.exceptions import UserError
+from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 from beets.ui.commands.import_ import paths_from_logfile
 from beets.ui.commands.import_.display import show_change
-from beets.ui.commands.import_.session import summarize_items
+from beets.ui.commands.import_.session import choose_candidate, summarize_items
 
 
 class ImportTest(BeetsTestCase):
@@ -63,11 +72,7 @@ class ShowChangeTestCase(IOMixin, BeetsTestCase):
         albumartist = f"another artist with {long_name}"
 
         def make_item(**kwargs):
-            item = library.Item(
-                album=album, albumartist=albumartist, length=60, format="F"
-            )
-            item.update(kwargs)
-            return item
+            return _common.item(album=album, albumartist=albumartist, **kwargs)
 
         items = [
             make_item(track=1, title="first title"),
@@ -161,6 +166,31 @@ class ShowChangeTestCase(IOMixin, BeetsTestCase):
         msg = self._show_change(artist_credit="credited artist")
         assert "credited artist - café" in msg
         assert "-> credited artist" in msg
+
+    def test_choose_candidate_respects_artist_credit(self):
+        from beets.util import PromptChoice
+
+        self.config["artist_credit"] = True
+        match = AlbumMatch(
+            distance=Distance(),
+            info=AlbumInfo(
+                album="an album",
+                album_id="album id",
+                artist="the canonical artist",
+                artist_credit="the credited artist",
+                artist_id="artist id",
+                tracks=[],
+            ),
+            mapping={},
+            extra_items=[],
+            extra_tracks=[],
+        )
+        source = Mock(type="album", desc="test desc")
+        choice = PromptChoice("s", "Skip", None)
+        with patch("beets.ui.input_options", return_value="s"):
+            choose_candidate([match], Recommendation.none, source, [choice])
+            out = self.io.getoutput()
+            assert "the credited artist - an album" in out
 
 
 @patch("beets.library.Item.try_filesize", Mock(return_value=987))


### PR DESCRIPTION
Fixes #5010.

### Problem

When `artist_credit: yes` is enabled, the importer UI still displayed the canonical artist name (`match.info.artist`) instead of the credited artist name in:
1. The match header (`Match (XX%): <artist> - <album>`)
2. The change details table (`≠ Artist: <original> -> <artist>`)
3. The interactive candidate list (`Candidates: 1. <artist> - <album>`)

Even though the actual library items had the credited artist applied via `raw_data()`, the UI reported a diff and indicated the canonical name would be written.

### Solution

- Added a `display_artist` property on `Info` (`AlbumInfo` / `TrackInfo`) that returns `artist_credit or artist` when `artist_credit` is enabled, falling back to `artist`.
- Updated `show_match_header`, `show_match_details`, and candidate list formatting in `choose_candidate` to use `display_artist`.
- Added unit tests in `test_hooks.py` and `test_import.py`.
- Added changelog entry under `Bug fixes`.
