### PR TITLE
web: resolve relative album artpath before serving art

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -392,7 +392,12 @@ def album_query(queries: Sequence[str]) -> Any:
 def album_art(album_id: int) -> Any:
     album = g.lib.get_album(album_id)
     if album and album.artpath:
-        return flask.send_file(album.artpath.decode())
+        artpath = album.artpath
+        # artpath may be stored relative to the library directory; resolve it
+        # to an absolute path so send_file doesn't look under the app root.
+        if not os.path.isabs(artpath):
+            artpath = os.path.join(g.lib.directory, artpath)
+        return flask.send_file(util.syspath(artpath))
     return flask.abort(404)
 
 

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 import flask
@@ -391,12 +392,11 @@ def album_query(queries: Sequence[str]) -> Any:
 @app.route("/album/<int:album_id>/art")
 def album_art(album_id: int) -> Any:
     album = g.lib.get_album(album_id)
-    if album and album.artpath:
-        artpath = album.artpath
+    if album and (artpath := album.art_filepath):
         # artpath may be stored relative to the library directory; resolve it
         # to an absolute path so send_file doesn't look under the app root.
-        if not os.path.isabs(artpath):
-            artpath = os.path.join(g.lib.directory, artpath)
+        if not artpath.is_absolute():
+            artpath = Path(os.fsdecode(g.lib.directory)) / artpath
         return flask.send_file(util.syspath(artpath))
     return flask.abort(404)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,9 @@ Bug fixes
   ``[mm:ss.xxx]``) in LRC parsing, fixing an issue where synced lyrics with
   millisecond precision were erroneously rejected and fell back to plain lyrics.
   :bug:`7001`
+- :doc:`plugins/web`: Fix a 500 error when serving album art for albums whose
+  ``artpath`` is stored relative to the library directory; the path is now
+  resolved against the library directory before the file is served.
 
 ..
     For plugin developers

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -675,6 +675,65 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
 
         assert response.status_code == 200
 
+    def test_get_album_art_relative_artpath(self):
+        # Some libraries store artpath relative to the music directory; the art
+        # route must resolve it against the library directory instead of 500ing.
+        import os
+        import threading
+
+        from beets.library import Library
+        from beets.util import syspath
+
+        # The ORM auto-absolutizes a relative artpath using a ContextVar
+        # that gets set when the Library is constructed (in this thread).
+        # A brand-new OS thread does NOT inherit that ContextVar, which is
+        # exactly what happens on the real web plugin's threaded dev server
+        # (app.run(threaded=True)): each request runs in a worker thread
+        # that never constructed the Library, so the artpath stays relative
+        # there. Run the request from a freshly spawned thread to reproduce
+        # that condition -- calling it from this (the Library-owning)
+        # thread would never exercise the bug.
+        #
+        # This also requires an on-disk database: the default test library
+        # is sqlite ":memory:", and each thread opens its own connection,
+        # so a worker thread would see an empty (tableless) database rather
+        # than a relative-path lookup. An on-disk file, like a real deployed
+        # library, is visible to every thread's connection.
+        dbpath = self.temp_path / "artpath_test.db"
+        lib = Library(str(dbpath), str(self.lib_path))
+        web.app.config["lib"] = lib
+        try:
+            rel = os.path.join(b"rel_art_dir", b"cover.png")
+            abspath = os.path.join(lib.directory, rel)
+            os.makedirs(os.path.dirname(syspath(abspath)), exist_ok=True)
+            with open(syspath(abspath), "wb") as f:
+                f.write(b"PNGDATA")
+
+            lib.add(Album(album="relartalbum", artpath=rel))
+            album_id = lib.albums("relartalbum").get().id
+
+            result = {}
+
+            def make_request() -> None:
+                try:
+                    response = self.client.get(f"/album/{album_id}/art")
+                    result["status_code"] = response.status_code
+                    result["data"] = response.data
+                except Exception as exc:  # re-raised in the main thread below
+                    result["exception"] = exc
+
+            thread = threading.Thread(target=make_request)
+            thread.start()
+            thread.join()
+
+            if "exception" in result:
+                raise result["exception"]
+            assert result["status_code"] == 200
+            assert result["data"] == b"PNGDATA"
+        finally:
+            web.app.config["lib"] = self.lib
+            lib._close()
+
 
 class TestWebXSS(WebPluginMixin, PytestTestHelper):
     """Tests for XSS vulnerability in the web plugin templates.

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -682,7 +682,7 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         import threading
 
         from beets.library import Library
-        from beets.util import syspath
+        from beets.util import bytestring_path
 
         # The ORM auto-absolutizes a relative artpath using a ContextVar
         # that gets set when the Library is constructed (in this thread).
@@ -703,13 +703,12 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         lib = Library(str(dbpath), str(self.lib_path))
         web.app.config["lib"] = lib
         try:
-            rel = os.path.join(b"rel_art_dir", b"cover.png")
-            abspath = os.path.join(lib.directory, rel)
-            os.makedirs(os.path.dirname(syspath(abspath)), exist_ok=True)
-            with open(syspath(abspath), "wb") as f:
-                f.write(b"PNGDATA")
+            rel = Path("rel_art_dir") / "cover.png"
+            abspath = Path(os.fsdecode(lib.directory)) / rel
+            abspath.parent.mkdir(parents=True, exist_ok=True)
+            abspath.write_bytes(b"PNGDATA")
 
-            lib.add(Album(album="relartalbum", artpath=rel))
+            lib.add(Album(album="relartalbum", artpath=bytestring_path(rel)))
             album_id = lib.albums("relartalbum").get().id
 
             result = {}


### PR DESCRIPTION
## Description

`GET /album/<id>/art` returns a 500 when an album's `artpath` is stored relative to the library directory.

`album_art()` passes `album.artpath` straight to `flask.send_file()`. beets stores `artpath` relative to the music directory and only resolves it lazily, through the `music_dir` ContextVar, in the thread that set it. The web server runs with `app.run(threaded=True)`, so worker threads never set that ContextVar; there the path stays relative and `send_file()` resolves it against the app root (`beetsplug/web/`), raising `FileNotFoundError`, so Flask returns a 500. Absolute artpaths are unaffected.

## Fix

Resolve a relative artpath against `g.lib.directory` before serving it, through `util.syspath()`:

```python
if not os.path.isabs(artpath):
    artpath = os.path.join(g.lib.directory, artpath)
return flask.send_file(util.syspath(artpath))
```

## Testing

Added a regression test that reproduces the failure from a separate thread (which, like the `threaded=True` workers, doesn't inherit the ContextVar) against an on-disk library, and asserts a 200 with the file's bytes. It fails without the fix and passes with it.

## To Do

- [x] Changelog.
- [x] Tests.
