### PR TITLE
util: handle empty path components and avoid leading slashes in destination paths

### DIFF
--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -568,7 +568,7 @@ class Album(LibModel):
         if beets.config["asciify_paths"]:
             subpath = util.asciify_path(subpath)
         subpath = util.sanitize_path(subpath, replacements=self.db.replacements)
-        subpath_bytes = bytestring_path(subpath)
+        subpath_bytes = bytestring_path(subpath).lstrip(b"\\/")
 
         _, ext = os.path.splitext(image)
         dest = os.path.join(item_dir, subpath_bytes + ext)
@@ -1290,7 +1290,7 @@ class Item(LibModel):
                 "the filename.",
                 subpath,
             )
-        lib_path_bytes = util.bytestring_path(lib_path_str)
+        lib_path_bytes = util.bytestring_path(lib_path_str).lstrip(b"\\/")
 
         if relative_to_libdir:
             return lib_path_bytes

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -685,14 +685,14 @@ def sanitize_path(path: str, replacements: Replacements | None = None) -> str:
     """
     replacements = replacements or CHAR_REPLACE
 
-    comps = components(path)
-    if not comps:
-        return ""
-    for i, comp in enumerate(comps):
+    comps = re.split(r"[\\/]", path)
+    new_comps = []
+    for comp in comps:
         for regex, repl in replacements:
             comp = regex.sub(repl, comp)
-        comps[i] = comp
-    return os.path.join(*comps)
+        if comp:
+            new_comps.append(comp)
+    return os.path.join(*new_comps) if new_comps else ""
 
 
 def truncate_str(s: str, length: int) -> str:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -685,7 +685,10 @@ def sanitize_path(path: str, replacements: Replacements | None = None) -> str:
     """
     replacements = replacements or CHAR_REPLACE
 
-    comps = re.split(r"[\\/]", path)
+    seps = os.path.sep
+    if os.path.altsep:
+        seps += os.path.altsep
+    comps = re.split(f"[{re.escape(seps)}]", path)
     new_comps = []
     for comp in comps:
         for regex, repl in replacements:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ Bug fixes
   ``[mm:ss.xxx]``) in LRC parsing, fixing an issue where synced lyrics with
   millisecond precision were erroneously rejected and fell back to plain lyrics.
   :bug:`7001`
+- Fix invalid destination paths with leading slashes when items have missing
+  metadata. :bug:`4889` :bug:`359`
 
 ..
     For plugin developers

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -492,8 +492,8 @@ class TestDestination(PytestItemHelper):
         item_in_db.path = "foo.mp3"
         dest = item_in_db.destination()
         assert not dest.startswith(b"//")
-        assert not dest.startswith(b"/")
         assert not dest.startswith(b"\\\\")
+        assert dest != b"/00.mp3"
         assert dest == np("base/00.mp3")
 
     def test_destination_stays_in_basedir_with_empty_leading_field(
@@ -1077,7 +1077,8 @@ class TestArtDestination(TestHelper):
         art = ai.art_destination("something.jpg")
         track = i.destination()
         assert not art.startswith(b"//")
-        assert not art.startswith(b"/")
+        assert not art.startswith(b"\\\\")
+        assert art != b"/artimage.jpg"
         assert os.path.dirname(art) == os.path.dirname(track)
 
 

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -7,7 +7,6 @@ import os.path
 import re
 import shutil
 import stat
-import unittest
 from pathlib import Path
 from unittest.mock import patch
 
@@ -461,7 +460,6 @@ class TestDestination(PytestItemHelper):
         item_in_db.album = "bar"
         assert item_in_db.destination() == np("base/ber/foo")
 
-    @unittest.skip("unimplemented: #359")
     def test_destination_with_empty_component(self, item_in_db):
         self.lib.directory = b"base"
         self.lib.replacements = [(re.compile(r"^$"), "_")]
@@ -472,7 +470,6 @@ class TestDestination(PytestItemHelper):
         item_in_db.album = "one"
         assert item_in_db.destination() == np("base/one/_/three")
 
-    @unittest.skip("unimplemented: #359")
     def test_destination_with_empty_final_component(self, item_in_db):
         self.lib.directory = b"base"
         self.lib.replacements = [(re.compile(r"^$"), "_")]
@@ -481,6 +478,33 @@ class TestDestination(PytestItemHelper):
         item_in_db.album = "one"
         item_in_db.path = "foo.mp3"
         assert item_in_db.destination() == np("base/one/_.mp3")
+
+    def test_destination_with_empty_leading_components(self, item_in_db):
+        self.lib.directory = b"base"
+        self.lib.path_formats = [
+            ("default", "$albumartist/$album/$track $title")
+        ]
+        item_in_db.title = ""
+        item_in_db.artist = ""
+        item_in_db.albumartist = ""
+        item_in_db.album = ""
+        item_in_db.track = 0
+        item_in_db.path = "foo.mp3"
+        dest = item_in_db.destination()
+        assert not dest.startswith(b"//")
+        assert not dest.startswith(b"/")
+        assert not dest.startswith(b"\\\\")
+        assert dest == np("base/00.mp3")
+
+    def test_destination_stays_in_basedir_with_empty_leading_field(
+        self, item_in_db
+    ):
+        self.lib.directory = b"base"
+        self.lib.replacements = [(re.compile(r"a"), "e")]
+        self.lib.path_formats = [("default", "$album/$title")]
+        item_in_db.album = ""
+        item_in_db.title = "three"
+        assert item_in_db.destination() == np("base/three")
 
     def test_album_field_query(self, item_in_db):
         self.lib.directory = b"one"
@@ -1044,6 +1068,17 @@ class TestArtDestination(TestHelper):
         config["art_filename"] = "artXimage"
         art = ai.art_destination("something.jpg")
         assert b"artYimage" in art
+
+    def test_art_destination_stays_in_item_dir_with_leading_separator(
+        self, item_and_album
+    ):
+        i, ai = item_and_album
+        config["art_filename"] = "/artimage"
+        art = ai.art_destination("something.jpg")
+        track = i.destination()
+        assert not art.startswith(b"//")
+        assert not art.startswith(b"/")
+        assert os.path.dirname(art) == os.path.dirname(track)
 
 
 class TestPathString(PytestItemHelper):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -92,6 +92,11 @@ class UtilTest(unittest.TestCase):
             p = util.sanitize_path("//00 ")
         assert p == "00"
 
+    def test_sanitize_backslash_on_posix(self):
+        with _common.platform_posix():
+            p = util.sanitize_path(r"foo\bar/baz")
+        assert p == "foo_bar/baz"
+
     @patch("beets.util.subprocess.Popen")
     def test_command_output(self, mock_popen):
         def popen_fail(*args, **kwargs):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -82,11 +82,15 @@ class UtilTest(unittest.TestCase):
             p = util.sanitize_path("foo/bar", [(re.compile(r"foo"), "bar")])
         assert p == "bar/bar"
 
-    @unittest.skip("unimplemented: #359")
     def test_sanitize_empty_component(self):
         with _common.platform_posix():
             p = util.sanitize_path("foo//bar", [(re.compile(r"^$"), "_")])
         assert p == "foo/_/bar"
+
+    def test_sanitize_empty_leading_components(self):
+        with _common.platform_posix():
+            p = util.sanitize_path("//00 ")
+        assert p == "00"
 
     @patch("beets.util.subprocess.Popen")
     def test_command_output(self, mock_popen):


### PR DESCRIPTION
## Description

Fixes #359.
Related to #4889.

Previously, `util.sanitize_path` called `components()`, which internally relied on `ancestry()`. This had two unintended side effects:
1. Intermediate empty path components (e.g. from `foo//bar` or missing path format fields like `$album` when empty) were dropped before `replacements` could inspect them. As described in #359, configuring `replacements = [(re.compile(r"^$"), "_")]` could never match empty components because `ancestry()` dropped them beforehand.
2. In path templates where leading components evaluate to empty strings (e.g. `$albumartist/$album/$track $title`), the resulting path had leading slashes (e.g. `//00 track.mp3`). On POSIX systems, `os.path.join(basedir, path)` treats paths with leading slashes as absolute paths from root, silently discarding `basedir` and attempting to write files to `/` or `//`, causing permission errors (#4889).

This PR:
- Updates `util.sanitize_path` to split components by path separators (`re.split(r"[\\/]", path)`), allowing `replacements` to match empty components (such as `^$`). If an empty component is not replaced (or is replaced with an empty string), it is omitted from the resulting joined path so leading slashes are never generated.
- In `Item.destination()` and `Album.art_destination()`, adds `.lstrip(b"\\/")` as defense-in-depth to ensure destination fragments are strictly relative to `basedir`.
- Unskips long-standing test cases for #359 (`test_sanitize_empty_component`, `test_destination_with_empty_component`, `test_destination_with_empty_final_component`) and adds regression tests for leading empty path components.

## To Do

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
