### PR TITLE
fetchart: fix cover_format conversion, deinterlace interaction, and alpha handling (#4452)

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -335,9 +335,15 @@ class IMBackend(LocalBackend):
     def convert_format(
         self, source: bytes, target: bytes, deinterlaced: bool
     ) -> bytes:
+        is_jpeg = target.lower().endswith((b".jpg", b".jpeg"))
         cmd = [
             *self.convert_cmd,
             syspath(source),
+            *(
+                ["-background", "white", "-alpha", "remove", "-alpha", "off"]
+                if is_jpeg
+                else []
+            ),
             *(["-interlace", "none"] if deinterlaced else []),
             syspath(target),
         ]
@@ -348,7 +354,11 @@ class IMBackend(LocalBackend):
             )
             return target
         except subprocess.CalledProcessError:
-            # FIXME: Should probably issue a warning?
+            log.warning(
+                "ImageMagick failed to convert image {} to {}",
+                displayable_path(source),
+                displayable_path(target),
+            )
             return source
 
     @property
@@ -599,6 +609,18 @@ class PILBackend(LocalBackend):
 
         try:
             with Image.open(syspath(source)) as im:
+                if target.lower().endswith((b".jpg", b".jpeg")):
+                    if im.mode in ("RGBA", "LA") or (
+                        im.mode == "P" and "transparency" in im.info
+                    ):
+                        rgba = im.convert("RGBA")
+                        background = Image.new(
+                            "RGB", rgba.size, (255, 255, 255)
+                        )
+                        background.paste(rgba, mask=rgba.split()[3])
+                        im = background
+                    elif im.mode != "RGB":
+                        im = im.convert("RGB")
                 im.save(os.fsdecode(target), progressive=not deinterlaced)
                 return target
         except (
@@ -766,22 +788,19 @@ class ArtResizer:
 
         new_format = new_format.lower()
         # A nonexhaustive map of image "types" to extensions overrides
-        new_format = {"jpeg": "jpg"}.get(new_format, new_format)
+        ext = {"jpeg": "jpg"}.get(new_format, new_format)
 
-        fname, _ = os.path.splitext(path_in)
-        path_new = fname + b"." + new_format.encode("utf8")
+        path_new = get_temp_filename(__name__, "reformat_", suffix=f".{ext}")
 
-        # allows the exception to propagate, while still making sure a changed
-        # file path was removed
         result_path = path_in
         try:
             result_path = self.local_method.convert_format(
                 path_in, path_new, deinterlaced
             )
         finally:
-            if result_path != path_in:
+            if result_path != path_new:
                 with suppress(OSError):
-                    os.unlink(path_in)
+                    os.unlink(path_new)
         return result_path
 
     @property

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -6,9 +6,10 @@ import os
 import re
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from contextlib import closing
+from contextlib import closing, suppress
 from enum import Enum
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, AnyStr, ClassVar, Literal, Protocol
 
 import confuse
@@ -208,7 +209,14 @@ class Candidate:
         reformat = False
         if plugin.cover_format:
             fmt = ArtResizer.shared.get_format(self.path)
-            reformat = fmt != plugin.cover_format
+            if fmt:
+                desired = plugin.cover_format.lower()
+                desired = {"jpg": "jpeg"}.get(desired, desired)
+                current = fmt.lower()
+                current = {"jpg": "jpeg"}.get(current, current)
+                reformat = current != desired
+            else:
+                reformat = True
             if reformat:
                 self._log.debug(
                     "image needs reformatting: {} -> {.cover_format}",
@@ -245,12 +253,14 @@ class Candidate:
         """
         # validate the candidate in case it hasn't been done yet
         current_check = self.validate(plugin)
-        checks_performed = []
+        checks_performed: list[ImageAction] = []
 
         # we don't want to resize the image if it's valid or bad
         while current_check not in [ImageAction.BAD, ImageAction.EXACT]:
             self._resize(plugin, current_check)
             checks_performed.append(current_check)
+            if current_check == ImageAction.REFORMAT and plugin.deinterlace:
+                checks_performed.append(ImageAction.DEINTERLACE)
             current_check = self.validate(
                 plugin, skip_check_for=checks_performed
             )
@@ -266,6 +276,7 @@ class Candidate:
         assert self.path is not None
         assert self.size is not None
 
+        old_path = self.path
         if check == ImageAction.DOWNSCALE:
             self.path = ArtResizer.shared.resize(
                 plugin.maxwidth,
@@ -290,6 +301,23 @@ class Candidate:
                 plugin.cover_format,  # type: ignore[arg-type]
                 deinterlaced=plugin.deinterlace,
             )
+
+        if self.path and self.path != old_path:
+            temp_dir = util.get_module_tempdir("beets.util.artresizer")
+            try:
+                if (
+                    Path(os.fsdecode(old_path))
+                    .resolve()
+                    .is_relative_to(temp_dir.resolve())
+                ):
+                    with suppress(OSError):
+                        os.unlink(old_path)
+            except (ValueError, OSError):
+                pass
+
+            new_size = ArtResizer.shared.get_size(self.path)
+            if new_size:
+                self.size = new_size
 
 
 def _logged_get(log: Logger, *args, **kwargs) -> requests.Response:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,11 @@ Bug fixes
   ``[mm:ss.xxx]``) in LRC parsing, fixing an issue where synced lyrics with
   millisecond precision were erroneously rejected and fell back to plain lyrics.
   :bug:`7001`
+- :doc:`plugins/fetchart`: Fix ``cover_format`` image reformatting when converting
+  between JPEG and PNG (normalizing format names, compositing transparent RGBA/LA
+  images onto a white background before JPEG conversion, avoiding redundant deinterlacing,
+  updating candidate dimensions across resize stages, and preventing source image deletion).
+  :bug:`4452`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,11 +20,11 @@ Bug fixes
   ``[mm:ss.xxx]``) in LRC parsing, fixing an issue where synced lyrics with
   millisecond precision were erroneously rejected and fell back to plain lyrics.
   :bug:`7001`
-- :doc:`plugins/fetchart`: Fix ``cover_format`` image reformatting when converting
-  between JPEG and PNG (normalizing format names, compositing transparent RGBA/LA
-  images onto a white background before JPEG conversion, avoiding redundant deinterlacing,
-  updating candidate dimensions across resize stages, and preventing source image deletion).
-  :bug:`4452`
+- :doc:`plugins/fetchart`: Fix ``cover_format`` image reformatting when
+  converting between JPEG and PNG (normalizing format names, compositing
+  transparent RGBA/LA images onto a white background before JPEG conversion,
+  avoiding redundant deinterlacing, updating candidate dimensions across resize
+  stages, and preventing source image deletion). :bug:`4452`
 
 ..
     For plugin developers

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -1039,6 +1039,13 @@ class TestAlbumArtPerformOperation(AlbumArtOperationMixin):
         ) as mocked:
             yield mocked
 
+    @pytest.fixture
+    def reformat_mock(self) -> Iterator[MagicMock]:
+        with patch.object(
+            ArtResizer.shared, "reformat", return_value=self.IMAGE_PATH
+        ) as mocked:
+            yield mocked
+
     def test_resize(self, resizer_mock):
         self.plugin.maxwidth = self.IMAGE_WIDTH / 2
         assert self.get_album_art()
@@ -1082,6 +1089,59 @@ class TestAlbumArtPerformOperation(AlbumArtOperationMixin):
         assert self.get_album_art()
         deinterlacer_mock.assert_called_once()
         resizer_mock.assert_called_once()
+
+    def test_reformat_same_format_not_called(self, reformat_mock):
+        """Reformat is not called when candidate already matches cover_format."""
+        self.plugin.cover_format = "jpeg"
+        assert self.get_album_art()
+        reformat_mock.assert_not_called()
+
+        self.plugin.cover_format = "jpg"
+        assert self.get_album_art()
+        reformat_mock.assert_not_called()
+
+        self.plugin.cover_format = "JPEG"
+        assert self.get_album_art()
+        reformat_mock.assert_not_called()
+
+    def test_reformat_called_when_format_differs(self, reformat_mock):
+        """Reformat is called when candidate format differs from cover_format."""
+        self.plugin.cover_format = "png"
+        assert self.get_album_art()
+        reformat_mock.assert_called_once_with(
+            self.IMAGE_PATH, "png", deinterlaced=False
+        )
+
+    def test_reformat_with_deinterlace_skips_redundant_deinterlace(
+        self, reformat_mock, deinterlacer_mock
+    ):
+        """When reformatting with deinterlace=True, reformat handles deinterlacing."""
+        self.plugin.cover_format = "png"
+        self.plugin.deinterlace = True
+        assert self.get_album_art()
+        reformat_mock.assert_called_once_with(
+            self.IMAGE_PATH, "png", deinterlaced=True
+        )
+        deinterlacer_mock.assert_not_called()
+
+    def test_reformat_and_resized(self, resizer_mock, reformat_mock):
+        """Both resize and reformat are called when both conditions are met."""
+        self.plugin.maxwidth = self.IMAGE_WIDTH / 2
+        self.plugin.cover_format = "png"
+        assert self.get_album_art()
+        resizer_mock.assert_called_once()
+        reformat_mock.assert_called_once()
+
+    def test_reformat_png_to_jpeg_integration(self):
+        """Integration test: candidate converts PNG to JPEG and preserves source."""
+        png_path = _common.RSRC / "image-2x3.png"
+        candidate = fetchart.Candidate(logger, "fs", png_path)
+        self.plugin.cover_format = "jpeg"
+        candidate.resize(self.plugin)
+        assert candidate.path != png_path
+        assert Path(os.fsdecode(candidate.path)).exists()
+        assert ArtResizer.shared.get_format(candidate.path) == "JPEG"
+        assert png_path.exists()
 
 
 class TestDeprecatedConfig:

--- a/test/util/test_art_resize.py
+++ b/test/util/test_art_resize.py
@@ -9,7 +9,7 @@ from beets.test import _common
 from beets.test.fixtures import DummyIMBackend
 from beets.test.helper import BeetsTestCase, CleanupModulesMixin
 from beets.util import command_output
-from beets.util.artresizer import IMBackend, PILBackend
+from beets.util.artresizer import ArtResizer, IMBackend, PILBackend
 
 
 class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
@@ -99,3 +99,56 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
         im.write_metadata("foo", metadata)
         command = [*im.convert_cmd, *"foo -set a A -set b B foo".split()]
         mock_util.command_output.assert_called_once_with(command)
+
+    @unittest.skipUnless(PILBackend.available(), "PIL not available")
+    def test_pil_convert_format_rgb(self):
+        """Test PILBackend.convert_format converts RGB image to JPEG."""
+        from PIL import Image
+
+        src_path = self.temp_path / "test_rgb.png"
+        Image.new("RGB", (10, 10), (0, 255, 0)).save(src_path)
+        dest_path = self.temp_path / "test_rgb.jpg"
+
+        result = PILBackend().convert_format(
+            os.fsencode(src_path), os.fsencode(dest_path), deinterlaced=True
+        )
+        assert result == os.fsencode(dest_path)
+        assert dest_path.exists()
+        with Image.open(dest_path) as im:
+            assert im.format == "JPEG"
+            assert im.mode == "RGB"
+
+    @unittest.skipUnless(PILBackend.available(), "PIL not available")
+    def test_pil_convert_format_rgba(self):
+        """Test PILBackend.convert_format handles RGBA alpha transparency."""
+        from PIL import Image
+
+        src_path = self.temp_path / "test_rgba.png"
+        Image.new("RGBA", (10, 10), (255, 0, 0, 128)).save(src_path)
+        dest_path = self.temp_path / "test_rgba.jpg"
+
+        result = PILBackend().convert_format(
+            os.fsencode(src_path), os.fsencode(dest_path), deinterlaced=True
+        )
+        assert result == os.fsencode(dest_path)
+        assert dest_path.exists()
+        with Image.open(dest_path) as im:
+            assert im.format == "JPEG"
+            assert im.mode == "RGB"
+
+    @unittest.skipUnless(PILBackend.available(), "PIL not available")
+    def test_reformat_preserves_source(self):
+        """Test ArtResizer.reformat creates a temp file without unlinking source."""
+        from PIL import Image
+
+        src_path = self.temp_path / "source.png"
+        Image.new("RGB", (10, 10), (0, 0, 255)).save(src_path)
+
+        resizer = ArtResizer()
+        result = resizer.reformat(os.fsencode(src_path), "jpeg")
+
+        # Source file must not be removed
+        assert src_path.exists()
+        # Result file must exist and be JPEG
+        assert Path(os.fsdecode(result)).exists()
+        assert resizer.get_format(result) == "JPEG"


### PR DESCRIPTION
## Description

Fixes #4452.

### Problem
When configuring `cover_format: jpeg` (or `jpg`) in `fetchart`, album art candidates were not properly reformatted, or in some cases encountered unexpected behavior or errors:
1. **Format comparison mismatch**: `ArtResizer.get_format()` returns uppercase `"JPEG"`, while configuration commonly uses `"jpg"` or `"jpeg"`. Comparing with `fmt != plugin.cover_format` caused candidates already in JPEG format to be marked for redundant reformatting, and `reformat()` did not reliably produce the expected match.
2. **RGBA/transparency crash on JPEG conversion**: When converting PNGs with an alpha channel (`RGBA`, `LA`, or `P` mode with transparency) to JPEG, Pillow raised `OSError: cannot write mode RGBA as JPEG`.
3. **Redundant deinterlacing loop**: `ArtResizer.reformat(..., deinterlaced=plugin.deinterlace)` already deinterlaces the converted image in both ImageMagick and PIL backends. In `Candidate.resize()`, `ImageAction.DEINTERLACE` was not marked as handled, causing an extra redundant deinterlace pass on an already reformatted image.
4. **Stale dimensions after resizing**: In multi-step processing (such as downscale + reformat), `Candidate.size` remained set to the original image dimensions instead of being updated to the resized dimensions.
5. **Local source file risk during reformat**: `ArtResizer.reformat` previously attempted to overwrite the original path and unlinked `path_in`, which could delete original artwork on the user's filesystem.

### Solution
- Normalized format strings (mapping `jpg` <-> `jpeg` and handling case-insensitivity) in `Candidate._validate`.
- Added canvas compositing in PIL (`RGBA`/`LA`/transparency flattened onto a solid white background) and ImageMagick (`-background white -alpha remove -alpha off`) before saving to JPEG.
- Marked `ImageAction.DEINTERLACE` as handled when `reformat()` runs with `deinterlace=True`.
- Updated `Candidate.size` after each resize/reformat step and safely unlinked only intermediate temporary files located in the `artresizer` temp directory, preserving original source files.
- Switched `ArtResizer.reformat()` to write to safe temporary files via `get_temp_filename()`.
- Added unit and integration tests in `test/plugins/test_art.py` and `test/util/test_art_resize.py`.

## To Do

- [x] ~Documentation~
- [x] Changelog.
- [x] Tests.
