### PR TITLE
fetchart: fix stream parameter override, early status check, and streaming bounds (#5454)

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -325,10 +325,14 @@ def _logged_get(log: Logger, *args, **kwargs) -> requests.Response:
         s.headers = {"User-Agent": "beets"}
         prepped = s.prepare_request(req)
         settings = s.merge_environment_settings(
-            prepped.url, {}, None, None, None
+            prepped.url,
+            send_kwargs.get("proxies", {}),
+            send_kwargs.get("stream"),
+            send_kwargs.get("verify"),
+            send_kwargs.get("cert"),
         )
         log.debug("{}: {.url}", message, prepped)
-        merged_kwargs: dict[Any, Any] = {**send_kwargs, **settings}
+        merged_kwargs: dict[Any, Any] = {**settings, **send_kwargs}
         return s.send(prepped, **merged_kwargs)
 
 
@@ -441,7 +445,27 @@ class RemoteArtSource(ArtSource):
                     candidate.url, stream=True, message="downloading image"
                 )
             ) as resp:
+                if resp.status_code >= 400:
+                    self._log.debug(
+                        "error fetching art: HTTP status {}", resp.status_code
+                    )
+                    return
+
                 ct = resp.headers.get("Content-Type", None)
+                max_filesize = getattr(plugin, "max_filesize", 0)
+
+                if max_filesize and resp.headers.get("Content-Length"):
+                    try:
+                        content_length = int(resp.headers["Content-Length"])
+                        if content_length > max_filesize:
+                            self._log.debug(
+                                "image is too large: {}B > {}B",
+                                content_length,
+                                max_filesize,
+                            )
+                            return
+                    except (ValueError, TypeError):
+                        pass
 
                 # Download the image to a temporary file. As some servers
                 # (notably fanart.tv) have proven to return wrong Content-Types
@@ -487,17 +511,33 @@ class RemoteArtSource(ArtSource):
                     )
 
                 filename = get_temp_filename(__name__, suffix=ext.decode())
-                with open(filename, "wb") as fh:
-                    # write the first already loaded part of the image
-                    fh.write(header)
-                    # download the remaining part of the image
-                    for chunk in data:
-                        fh.write(chunk)
-                self._log.debug(
-                    "downloaded art to: {}", util.displayable_path(filename)
-                )
-                candidate.path = util.bytestring_path(filename)
-                return
+                total_size = len(header)
+                try:
+                    with open(filename, "wb") as fh:
+                        # write the first already loaded part of the image
+                        fh.write(header)
+                        # download the remaining part of the image
+                        for chunk in data:
+                            total_size += len(chunk)
+                            if max_filesize and total_size > max_filesize:
+                                self._log.debug(
+                                    "image exceeded maximum allowed size of {}B",
+                                    max_filesize,
+                                )
+                                break
+                            fh.write(chunk)
+                        else:
+                            self._log.debug(
+                                "downloaded art to: {}",
+                                util.displayable_path(filename),
+                            )
+                            candidate.path = util.bytestring_path(filename)
+                            return
+                    util.remove(filename)
+                    return
+                except Exception:
+                    util.remove(filename)
+                    raise
 
         except (OSError, requests.RequestException, TypeError) as exc:
             # Handling TypeError works around a urllib3 bug:
@@ -1242,7 +1282,7 @@ class Spotify(RemoteArtSource):
             return
 
         try:
-            response = requests.get(url, timeout=10)
+            response = self.request(url)
             response.raise_for_status()
         except requests.RequestException as e:
             self._log.debug("Error: {!s}", e)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,11 @@ Bug fixes
   ``[mm:ss.xxx]``) in LRC parsing, fixing an issue where synced lyrics with
   millisecond precision were erroneously rejected and fell back to plain lyrics.
   :bug:`7001`
+- :doc:`plugins/fetchart`: Fix ``_logged_get`` environment settings merge
+  overriding explicit request parameters (such as ``stream=True``), prevent
+  downloading when servers respond with HTTP error status codes, enforce
+  ``max_filesize`` during streaming downloads, and ensure temporary files are
+  cleaned up on download failures. :bug:`5454`
 
 ..
     For plugin developers

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -12,7 +12,13 @@ from beets.test.helper import (
     PluginMixin,
     PluginTestHelper,
 )
-from beetsplug.fetchart import CoverArtArchive, FetchArtPlugin, FileSystem
+from beetsplug.fetchart import (
+    Candidate,
+    CoverArtArchive,
+    FetchArtPlugin,
+    FileSystem,
+    _logged_get,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -199,3 +205,107 @@ class TestFetchartCli(IOMixin, PluginTestHelper):
         )
         fa = FetchArtPlugin()
         assert len(fa.sources) == 3
+
+
+class TestFetchartRemoteDownload(PluginTestHelper):
+    plugin = "fetchart"
+
+    def test_logged_get_preserves_stream_and_send_kwargs(self):
+        log = mock.MagicMock()
+        with mock.patch("requests.Session.send") as mock_send:
+            mock_send.return_value = mock.MagicMock()
+            _logged_get(
+                log, "https://example.com/art.jpg", stream=True, timeout=15
+            )
+            mock_send.assert_called_once()
+            _, kwargs = mock_send.call_args
+            assert kwargs["stream"] is True
+            assert kwargs["timeout"] == 15
+
+    def test_logged_get_default_timeout(self):
+        log = mock.MagicMock()
+        with mock.patch("requests.Session.send") as mock_send:
+            mock_send.return_value = mock.MagicMock()
+            _logged_get(log, "https://example.com/art.jpg")
+            mock_send.assert_called_once()
+            _, kwargs = mock_send.call_args
+            assert kwargs["timeout"] == 10
+
+    def test_fetch_image_early_exit_on_http_error(self):
+        log = mock.MagicMock()
+        source = CoverArtArchive(log, self.config["fetchart"])
+        plugin = FetchArtPlugin()
+        candidate = Candidate(
+            log, source.ID, url="https://example.com/error.jpg"
+        )
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 404
+        with mock.patch.object(source, "request", return_value=mock_resp):
+            source.fetch_image(candidate, plugin)
+
+        assert candidate.path is None
+        mock_resp.iter_content.assert_not_called()
+
+    def test_fetch_image_content_length_exceeds_max_filesize(self):
+        log = mock.MagicMock()
+        source = CoverArtArchive(log, self.config["fetchart"])
+        plugin = FetchArtPlugin()
+        plugin.max_filesize = 5000
+        candidate = Candidate(
+            log, source.ID, url="https://example.com/large.jpg"
+        )
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"Content-Length": "10000"}
+        with mock.patch.object(source, "request", return_value=mock_resp):
+            source.fetch_image(candidate, plugin)
+
+        assert candidate.path is None
+        mock_resp.iter_content.assert_not_called()
+
+    def test_fetch_image_streaming_exceeds_max_filesize(self):
+        log = mock.MagicMock()
+        source = CoverArtArchive(log, self.config["fetchart"])
+        plugin = FetchArtPlugin()
+        plugin.max_filesize = 50
+        candidate = Candidate(log, source.ID, url="https://example.com/art.jpg")
+
+        # Valid JPEG header (32 bytes) followed by chunk that exceeds 50 bytes total
+        jpeg_header = b"\xff\xd8\xff\xe0" + b"\x00" * 28
+        chunk = b"x" * 40
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"Content-Type": "image/jpeg"}
+        mock_resp.iter_content.return_value = iter([jpeg_header, chunk])
+
+        with mock.patch.object(source, "request", return_value=mock_resp):
+            source.fetch_image(candidate, plugin)
+
+        assert candidate.path is None
+
+    def test_fetch_image_cleanup_on_download_exception(self):
+        import requests
+
+        log = mock.MagicMock()
+        source = CoverArtArchive(log, self.config["fetchart"])
+        plugin = FetchArtPlugin()
+        candidate = Candidate(log, source.ID, url="https://example.com/art.jpg")
+
+        jpeg_header = b"\xff\xd8\xff\xe0" + b"\x00" * 28
+
+        def failing_chunks():
+            yield jpeg_header
+            raise requests.exceptions.ReadTimeout("read timed out")
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"Content-Type": "image/jpeg"}
+        mock_resp.iter_content.return_value = failing_chunks()
+
+        with mock.patch.object(source, "request", return_value=mock_resp):
+            source.fetch_image(candidate, plugin)
+
+        assert candidate.path is None


### PR DESCRIPTION
## Problem

In `fetchart`, remote image downloads could hang indefinitely or consume excessive resources when servers fail to respond, drop connections, or serve oversized payloads (#5454).

Three distinct root causes were identified:
1. **`stream` override bug in `_logged_get`**: `_logged_get` prepares requests and calls `settings = s.merge_environment_settings(prepped.url, {}, None, None, None)`. Because `settings` was unpacked second (`merged_kwargs = {**send_kwargs, **settings}`), the default `'stream': False` in `settings` overwrote any explicit `stream=True` passed in `send_kwargs` (e.g. from `RemoteArtSource.fetch_image`). Consequently, `requests.Session.send` downloaded the entire image payload into memory upfront rather than genuinely streaming the response.
2. **Missing HTTP status code check**: `RemoteArtSource.fetch_image` did not check `resp.status_code`. If a server or gateway returned an error response (e.g., HTTP 404, 500, 502 Bad Gateway, 503 Service Unavailable), the plugin attempted to read the error page body as an image.
3. **Unbounded streaming and unmanaged temporary files**: During chunk streaming in `RemoteArtSource.fetch_image`, `plugin.max_filesize` was not enforced while downloading chunks (only post-facto in validation). Furthermore, if a network error (e.g., `requests.exceptions.ReadTimeout`) occurred mid-stream, the partial temporary file remained orphaned on disk because `candidate.path` was never set.

## Solution

1. **Fix `_logged_get` environment settings merge**:
   - Forward explicit caller parameters (`proxies`, `stream`, `verify`, `cert`) to `s.merge_environment_settings()`.
   - Ensure caller settings take precedence over environment defaults: `{**settings, **send_kwargs}`.
2. **Early exit on HTTP error status codes**:
   - In `RemoteArtSource.fetch_image`, immediately abort and log if `resp.status_code >= 400`.
3. **Proactive file size checks**:
   - Check `Content-Length` header against `plugin.max_filesize` prior to downloading.
   - Enforce `plugin.max_filesize` iteratively during chunk streaming, immediately aborting and cleaning up if the downloaded size exceeds the limit.
4. **Safe temporary file cleanup**:
   - Wrap the chunk streaming loop in a `try...except Exception:` block to ensure any aborted or failed download cleans up the temporary file on disk.
5. **Spotify source consistency**:
   - Switched `Spotify.get` to use `self.request` for consistent logging and environment settings.
6. **Tests & Documentation**:
   - Added `TestFetchartRemoteDownload` covering `stream` parameter preservation, default timeout, HTTP error handling, `Content-Length` bounds, chunk streaming bounds, and exception cleanup.
   - Added changelog entry formatted with `docstrfmt --preserve-adornments`.

Fixes #5454
