### PR TITLE
Store token files with 0600 permissions

### DIFF
--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -13,6 +13,7 @@ Put something like the following in your config.yaml to configure:
 from __future__ import annotations
 
 import json
+import os
 import time
 import uuid
 import webbrowser
@@ -127,7 +128,12 @@ class PlexSession(TimeoutAndRetrySession):
         """Merge data into the token file and persist it."""
         token = self.load_token()
         token.update(data)
-        self.token_path.write_text(json.dumps(token, indent=2))
+        fd = os.open(
+            self.token_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+        )
+        with os.fdopen(fd, "w") as f:
+            json.dump(token, f, indent=2)
+        os.chmod(self.token_path, 0o600)
 
     def request(self, *args, **kwargs) -> requests.Response:
         """Send a request, attaching the auth token."""

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import base64
 import collections
 import json
+import os
 import re
 import threading
 import time
@@ -218,8 +219,11 @@ class SpotifyPlugin(
 
         # Save the token for later use.
         self._log.debug("{0.data_source} access token: {0.access_token}", self)
-        with open(self._tokenfile(), "w") as f:
+        path = self._tokenfile()
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
             json.dump({"access_token": self.access_token}, f)
+        os.chmod(path, 0o600)
 
     def _handle_response(
         self,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,11 @@ Bug fixes
   ``[mm:ss.xxx]``) in LRC parsing, fixing an issue where synced lyrics with
   millisecond precision were erroneously rejected and fell back to plain lyrics.
   :bug:`7001`
+- :doc:`plugins/spotify`, :doc:`plugins/plexupdate`: Create token files with
+  ``0600`` permissions so that stored credentials are not readable by other
+  users on the system.
+  :bug:`6984`
+
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,9 +22,7 @@ Bug fixes
   :bug:`7001`
 - :doc:`plugins/spotify`, :doc:`plugins/plexupdate`: Create token files with
   ``0600`` permissions so that stored credentials are not readable by other
-  users on the system.
-  :bug:`6984`
-
+  users on the system. :bug:`6984`
 
 ..
     For plugin developers


### PR DESCRIPTION
Token files in the Spotify and Plex plugins were created with the
process umask, which on a default umask of 022 leaves them
world-readable. Both are now created with 0600, with an explicit
chmod afterwards so files written by earlier versions get tightened
on the next write.

Note that os.chmod has no real effect on Windows, so this is a
POSIX-only improvement.