### PR TITLE
discogs: read the release month and day from `released`

### DIFF
--- a/beetsplug/discogs/__init__.py
+++ b/beetsplug/discogs/__init__.py
@@ -68,6 +68,10 @@ TRACK_INDEX_RE = re.compile(
     re.VERBOSE,
 )
 
+RELEASE_DATE_RE = re.compile(
+    r"(?P<year>\d{4})(?:-(?P<month>\d{1,2})(?:-(?P<day>\d{1,2}))?)?"
+)
+
 FIELDS_TO_DISCOGS_KEYS = {
     "barcode": "barcode",
     "catalognum": "catno",
@@ -76,6 +80,27 @@ FIELDS_TO_DISCOGS_KEYS = {
     "media": "format",
     "year": "year",
 }
+
+
+def parse_release_date(
+    released: str | None, year: int | None
+) -> tuple[int | None, int | None, int | None]:
+    """Return the ``(year, month, day)`` a release was issued on.
+
+    Discogs reports the year of a release in its own field but the rest of
+    the date only as part of `released`, which is absent or partial for many
+    releases. `year` is therefore used for any component `released` does not
+    provide.
+    """
+    if not (m := RELEASE_DATE_RE.fullmatch((released or "").strip())):
+        return year, None, None
+
+    released_year, month, day = (
+        int(i) if i else 0 for i in m.group("year", "month", "day")
+    )
+
+    # A zero stands for "unknown" in Discogs' dates, as does a missing group.
+    return released_year or year, month or None, day or None
 
 
 class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
@@ -376,7 +401,9 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
 
         # Extract information for the optional AlbumInfo fields, if possible.
         va = albumartist.artist == config["va_name"].as_str()
-        year = result.data.get("year")
+        year, month, day = parse_release_date(
+            result.data.get("released"), result.data.get("year")
+        )
         mediums = [t["medium"] for t in tracks]
         country = result.data.get("country")
         data_url = result.data.get("uri")
@@ -423,9 +450,14 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
 
         # Retrieve master release id (returns None if there isn't one).
         master_id = result.data.get("master_id")
-        # Assume `original_year` is equal to `year` for releases without
-        # a master release, otherwise fetch the master release.
-        original_year = self.get_master_year(master_id) if master_id else year
+        # Assume this release *is* the original when it has no master
+        # release, otherwise fetch the master release. Only its year is
+        # available, so the original month and day stay unknown there.
+        if master_id:
+            original_year = self.get_master_year(master_id)
+            original_month = original_day = None
+        else:
+            original_year, original_month, original_day = year, month, day
 
         return AlbumInfo(
             album=album,
@@ -435,6 +467,8 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
             albumtype=albumtype,
             va=va,
             year=year,
+            month=month,
+            day=day,
             label=label,
             mediums=len(set(mediums)),
             releasegroup_id=master_id,
@@ -446,6 +480,8 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
             genres=sorted(genres),
             media=media,
             original_year=original_year,
+            original_month=original_month,
+            original_day=original_day,
             data_source=self.data_source,
             data_url=data_url,
             discogs_albumid=discogs_albumid,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,9 @@ Bug fixes
 - Skip archive importer tests (``TestImport7z`` and ``TestImportRar``) when
   their optional dependencies (``py7zr`` or ``rarfile`` / ``unrar``) are not
   available. :bug:`7002`
+- :doc:`plugins/discogs`: Read the release month and day from the API's
+  ``released`` field instead of only the year. Fix Discogs match overwriting
+  month and day tags on import.
 
 ..
     For plugin developers

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -242,6 +242,60 @@ class TestDGAlbumInfo(DiscogsTestMixin, TestHelper):
         assert d.style is None
         assert d.genres == ["GENRE1", "GENRE2"]
 
+    @pytest.mark.parametrize(
+        "released, expected",
+        [
+            _p("2000-08-13", (2000, 8, 13), id="full-date"),
+            _p("2000-08", (2000, 8, None), id="year-and-month"),
+            _p("2000", (2000, None, None), id="year-only"),
+            _p("2000-00-00", (2000, None, None), id="zeroed-month-and-day"),
+            _p("2000-08-00", (2000, 8, None), id="zeroed-day"),
+            _p("2000-8-1", (2000, 8, 1), id="unpadded"),
+            _p("  2000-08-13  ", (2000, 8, 13), id="surrounding-whitespace"),
+            # Fall back to the release's own `year` field.
+            _p("", (3001, None, None), id="empty"),
+            _p(None, (3001, None, None), id="missing"),
+            _p("0000-00-00", (3001, None, None), id="zeroed-date"),
+            _p("13 Aug 2000", (3001, None, None), id="unparseable"),
+        ],
+    )
+    def test_parse_release_date(self, released, expected):
+        release = self._make_release_from_positions(["1"])
+        release.data["released"] = released
+
+        d = DiscogsPlugin().get_album_info(release)
+
+        assert (d.year, d.month, d.day) == expected
+
+    def test_original_date_without_master(self):
+        """A release without a master release is its own original."""
+        release = self._make_release_from_positions(["1"])
+        release.data["released"] = "2000-08-13"
+
+        d = DiscogsPlugin().get_album_info(release)
+
+        assert (d.original_year, d.original_month, d.original_day) == (
+            2000,
+            8,
+            13,
+        )
+
+    def test_original_date_with_master(self, monkeypatch):
+        """Only the master release's year is known, so it alone is used."""
+        monkeypatch.setattr(DiscogsPlugin, "get_master_year", lambda *_: 1990)
+        release = self._make_release_from_positions(["1"])
+        release.data["released"] = "2000-08-13"
+        release.data["master_id"] = 22222222
+
+        d = DiscogsPlugin().get_album_info(release)
+
+        assert (d.year, d.month, d.day) == (2000, 8, 13)
+        assert (d.original_year, d.original_month, d.original_day) == (
+            1990,
+            None,
+            None,
+        )
+
 
 class TestStripDisambiguation(DiscogsTestMixin):
     @pytest.fixture


### PR DESCRIPTION
## Description

The Discogs API reports a release's full date in `released` ("2000-08-13"), and only its year in `year`. `get_album_info` reads `year` alone, so every Discogs match carries an empty month and day. On top of that, `AlbumInfo` turns a set year into an explicit `month = 0, day = 0`, so applying a Discogs match actively cleared those tags rather than merely failing to fill them.

To obtain a full release date, parse `released`. Unfortunately, the documentation doesn't provide an accurate description of an expected format. To my observation, `released` dates are loosely ISO8601-complaint, with month and day being optional. Unknown component may be present but zero (e.g. `2000-00-00`), so zeroes are treated as unknown.

Unparsable dates fall back to `year`.

A release with no master release is already assumed to be its own original in the existing code, so `month` and `day` are used to fill `original_month` and `original_day`.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
