### PR TITLE
docs: create AI_POLICY.md

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -2,22 +2,24 @@
 
 The beetbox maintainers have put together the following rules for using AI in the beets project:
 
-- **Agents may only interact with the repository for code review** Creating pull requests, posting comments, and other interactions on the repository must be done by a human.
+- **Agents may only interact with the repository for code review.** Using an agent for creating pull requests, opening issues, and posting comments under your username is not permitted.
 
-- **AI is not for "good first contribution" issues** The goal is not the fix, but to create an easy entry point to the project that fosters longstanding community contributions.
+- **AI disclosure is required.** If you're writing the code using an LLM, disclose the usage and the extent to which it was used. This helps maintainers approach the contribution appropriately.
+
+- **AI is not for "good first contribution" issues.** The goal is not the fix with these issues, but to create an easy entry point to the project that fosters longstanding community contributions.
+
+- **AI code comments must be kept concise.** AI models have a tendency to write verbose and unnecessary comments - please edit these down and make sure they are relevant to the code at hand.
 
 - **Bad faith AI contributions will be ignored.** If a maintainer suspects that a pull request is being handled by an agent, it will be marked as draft pending contributor input, and closed if the contributor does not take over the communication from the agent.
 
-- **AI disclosure is recommended.** If you're writing the code using an agent, disclosing its usage and the extent helps maintainers approach the pull request with a better understanding of how it was put together.
-
-- **AI code comments must be kept concise.** AI models have a tendency to write verbose and unnecessary comments - please edit these down and make sure they are relevant to the code at hand. 
-
 ## Rationale
 
-Large numbers of low effort AI contributions bog-down reviews and create excess noise and work in reviewing pull requests for a volunteer run project.
+Large numbers of low-effort AI contributions bog down reviews and create noise and excess work in reviewing pull requests for a volunteer run project.
 
 This policy aims to improve community standards with using AI tools effectively while respecting the time and effort of all contributors and maintainers.
 
-We will have questions about your PR, and we need you to understand the proposed changes in order to dicuss with us
-what the implications are. We value human oversight and accountability, AI as a tool, not a contributor. 
+We will have questions about your PR, and we need you to understand the proposed changes in order to discuss with us
+what the implications are.
+
+We value human oversight and accountability, AI is a tool, not a contributor. 
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,23 @@
+# AI Usage Policy
+
+The beetbox maintainers have put together the following rules for using AI in the beets project:
+
+- **Agents may only interact with the repository for code review** Creating pull requests, posting comments, and other interactions on the repository must be done by a human.
+
+- **AI is not for "good first contribution" issues** The goal is not the fix, but to create an easy entry point to the project that fosters longstanding community contributions.
+
+- **Bad faith AI contributions will be ignored.** If a maintainer suspects that a pull request is being handled by an agent, it will be marked as draft pending contributor input, and closed if the contributor does not take over the communication from the agent.
+
+- **AI disclosure is recommended.** If you're writing the code using an agent, disclosing its usage and the extent helps maintainers approach the pull request with a better understanding of how it was put together.
+
+- **AI code comments must be kept concise.** AI models have a tendency to write verbose and unnecessary comments - please edit these down and make sure they are relevant to the code at hand. 
+
+## Rationale
+
+Large numbers of low effort AI contributions bog-down reviews and create excess noise and work in reviewing pull requests for a volunteer run project.
+
+This policy aims to improve community standards with using AI tools effectively while respecting the time and effort of all contributors and maintainers.
+
+We will have questions about your PR, and we need you to understand the proposed changes in order to dicuss with us
+what the implications are. We value human oversight and accountability, AI as a tool, not a contributor. 
+


### PR DESCRIPTION
## Description

I've noticed a few open source projects adding an AI_POLICY.md to their repositories. Considering the amount of PR's we're getting that seem to be fully automated - I think adding one could be a good and obvious mark of our policy with primarily AI driven contributions.

This is an early draft and I would like input from other maintainers to shape this to reflect how we use AI tools on the beets project.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
