### PR TITLE
Run CI when PR is queued in merge queue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: Test
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master


### PR DESCRIPTION
- Adds the `merge_group` trigger to `.github/workflows/ci.yaml` so the main CI workflow runs for GitHub merge queue events, not just `pull_request` and `push`.
